### PR TITLE
Chore: renovate.json 수정

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,26 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
-  ]
+  "extends": ["config:recommended"],
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "groupName": "all non-major dependencies",
+      "groupSlug": "all-minor-patch",
+      "automerge": true,
+      "automergeType": "branch"
+    },
+    {
+      "matchDepTypes": ["devDependencies"],
+      "groupName": "dev dependencies",
+      "groupSlug": "dev-deps",
+      "automerge": true,
+      "automergeType": "branch"
+    }
+  ],
+  "lockFileMaintenance": {
+    "enabled": true
+  },
+  "automerge": true,
+  "platformAutomerge": true,
+  "schedule": ["before 4am on monday"]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -15,12 +15,15 @@
       "groupSlug": "dev-deps",
       "automerge": true,
       "automergeType": "branch"
+    },
+    {
+      "matchUpdateTypes": ["major"],
+      "automerge": false
     }
   ],
   "lockFileMaintenance": {
     "enabled": true
   },
-  "automerge": true,
   "platformAutomerge": true,
   "schedule": ["before 4am on monday"]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -22,7 +22,9 @@
     }
   ],
   "lockFileMaintenance": {
-    "enabled": true
+    "enabled": true,
+    "automerge": true,
+    "automergeType": "branch"
   },
   "platformAutomerge": true,
   "schedule": ["before 4am on monday"]


### PR DESCRIPTION
## 📌 Summary
> - #32 

## 📚 Tasks
- renovate.json 수정

## 👀 To Reviewer
Renovate의 자동 머지 및 그룹핑 설정을 추가했습니다.

###  자동 머지 대상
- ✅ minor/patch 업데이트 (1.2.0 → 1.3.0, 1.2.1)
- ✅ devDependencies 모든 업데이트
- ✅ 락 파일 유지보수
- ❌ major 업데이트 (수동 검토 필요)

###  그룹핑 
- 여러 minor/patch 업데이트 → **1개의 "all non-major dependencies" PR**
- 여러 devDependencies 업데이트 → **1개의 "dev dependencies" PR**

> PR 스팸 방지 및 관리 효율성 증대를 기대할 수 있습니다.

### 실행 스케줄
- **월요일 새벽 4시 전** 주 1회 실행

> 주로 커밋하지 않는 시간으로 설정하였습니다.

###  검증 과정
- CI/테스트 통과 시에만 자동 머지
- 충돌 발생 시 자동 머지 중단

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Renovate 자동화 설정이 확장되어 패키지 업데이트 그룹화, 자동 병합, 잠금 파일 유지 관리, 운영 일정 지정 등이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->