### PR TITLE
Feat: Playwright 초기 설정

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -15,7 +15,7 @@ jobs:
         node-version: lts/*
     - name: Install pnpm
       run: npm install -g pnpm
-    - name: Install dependencies  
+    - name: Install dependencies
       run: pnpm install --frozen-lockfile
     - name: Build Next.js app
       run: pnpm build

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Install Playwright Browsers
       run: pnpm exec playwright install --with-deps
     - name: Run Playwright tests
-      run: pnpm test 
+      run: pnpm test
     - uses: actions/upload-artifact@v4
       if: ${{ !cancelled() }}
       with:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -13,8 +13,10 @@ jobs:
     - uses: actions/setup-node@v4
       with:
         node-version: lts/*
-    - name: Install dependencies
-      run: npm install -g pnpm && pnpm install
+    - name: Install pnpm
+      run: npm install -g pnpm
+    - name: Install dependencies  
+      run: pnpm install --frozen-lockfile
     - name: Build Next.js app
       run: pnpm build
     - name: Install Playwright Browsers

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,0 +1,27 @@
+name: Playwright Tests
+on:
+  push:
+    branches: [ main, develop ]
+  pull_request:
+    branches: [ main, develop ]
+jobs:
+  test:
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
+      with:
+        node-version: lts/*
+    - name: Install dependencies
+      run: npm install -g pnpm && pnpm install
+    - name: Install Playwright Browsers
+      run: pnpm exec playwright install --with-deps
+    - name: Run Playwright tests
+      run: pnpm test 
+    - uses: actions/upload-artifact@v4
+      if: ${{ !cancelled() }}
+      with:
+        name: playwright-report
+        path: playwright-report/
+        retention-days: 30

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -15,6 +15,8 @@ jobs:
         node-version: lts/*
     - name: Install dependencies
       run: npm install -g pnpm && pnpm install
+    - name: Build Next.js app
+      run: pnpm build
     - name: Install Playwright Browsers
       run: pnpm exec playwright install --with-deps
     - name: Run Playwright tests

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,10 @@ next-env.d.ts
 
 *storybook.log
 storybook-static
+
+# Playwright
+node_modules/
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,0 +1,12 @@
+import Link from "next/link";
+
+const About = () => {
+  return (
+    <div>
+      <h1>About</h1>
+      <Link href="/">Home</Link>
+    </div>
+  );
+};
+
+export default About;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,3 +1,12 @@
-export default function Home() {
-  return <div></div>;
-}
+import Link from "next/link";
+
+const Home = () => {
+  return (
+    <div>
+      <h1>Home</h1>
+      <Link href="/about">About</Link>
+    </div>
+  );
+};
+
+export default Home;

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "prepare": "lefthook install",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
-    "chromatic": "npx chromatic"
+    "chromatic": "npx chromatic",
+    "test": "playwright test",
+    "test:ui": "playwright test -c ./playwright.config.ts tests --ui"
   },
   "dependencies": {
     "@tanstack/react-query": "^5.77.2",
@@ -30,6 +32,7 @@
     "@biomejs/biome": "^1.9.4",
     "@commitlint/cli": "^19.8.1",
     "@commitlint/config-conventional": "^19.8.1",
+    "@playwright/test": "^1.53.1",
     "@storybook/addon-onboarding": "^9.0.1",
     "@storybook/nextjs": "^9.0.1",
     "@types/node": "^22.0.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,37 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./tests",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: "html",
+  use: {
+    baseURL: "http://localhost:3000",
+    trace: "on-first-retry",
+  },
+
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+
+    {
+      name: "firefox",
+      use: { ...devices["Desktop Firefox"] },
+    },
+
+    {
+      name: "webkit",
+      use: { ...devices["Desktop Safari"] },
+    },
+  ],
+
+  webServer: {
+    command: "pnpm run start",
+    url: "http://localhost:3000",
+    reuseExistingServer: !process.env.CI,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,7 +31,7 @@ importers:
         version: 1.8.1
       next:
         specifier: 15.3.4
-        version: 15.3.4(@babel/core@7.27.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 15.3.4(@babel/core@7.27.4)(@playwright/test@1.53.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react:
         specifier: ^19.0.0
         version: 19.1.0
@@ -48,12 +48,15 @@ importers:
       '@commitlint/config-conventional':
         specifier: ^19.8.1
         version: 19.8.1
+      '@playwright/test':
+        specifier: ^1.53.1
+        version: 1.53.1
       '@storybook/addon-onboarding':
         specifier: ^9.0.1
         version: 9.0.12(storybook@9.0.12(@testing-library/dom@10.4.0))
       '@storybook/nextjs':
         specifier: ^9.0.1
-        version: 9.0.12(esbuild@0.25.5)(next@15.3.4(@babel/core@7.27.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.12(@testing-library/dom@10.4.0))(type-fest@2.19.0)(typescript@5.8.3)(webpack-hot-middleware@2.26.1)(webpack@5.99.9(esbuild@0.25.5))
+        version: 9.0.12(esbuild@0.25.5)(next@15.3.4(@babel/core@7.27.4)(@playwright/test@1.53.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.12(@testing-library/dom@10.4.0))(type-fest@2.19.0)(typescript@5.8.3)(webpack-hot-middleware@2.26.1)(webpack@5.99.9(esbuild@0.25.5))
       '@types/node':
         specifier: ^22.0.0
         version: 22.15.32
@@ -65,7 +68,7 @@ importers:
         version: 19.1.6(@types/react@19.1.8)
       '@vanilla-extract/next-plugin':
         specifier: ^2.4.11
-        version: 2.4.14(next@15.3.4(@babel/core@7.27.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(webpack@5.99.9(esbuild@0.25.5))
+        version: 2.4.14(next@15.3.4(@babel/core@7.27.4)(@playwright/test@1.53.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(webpack@5.99.9(esbuild@0.25.5))
       '@vanilla-extract/webpack-plugin':
         specifier: ^2.3.19
         version: 2.3.22(webpack@5.99.9(esbuild@0.25.5))
@@ -1112,6 +1115,11 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@playwright/test@1.53.1':
+    resolution: {integrity: sha512-Z4c23LHV0muZ8hfv4jw6HngPJkbbtZxTkxPNIg7cJcTc9C28N/p2q7g3JZS2SiKBBHJ3uM1dgDye66bB7LEk5w==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   '@pmmmwh/react-refresh-webpack-plugin@0.5.16':
     resolution: {integrity: sha512-kLQc9xz6QIqd2oIYyXRUiAp79kGpFBm3fEM9ahfG1HI0WI5gdZ2OVHWdmZYnwODt7ISck+QuQ6sBPrtvUBML7Q==}
     engines: {node: '>= 10.13'}
@@ -2102,6 +2110,11 @@ packages:
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -2773,6 +2786,16 @@ packages:
 
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
+
+  playwright-core@1.53.1:
+    resolution: {integrity: sha512-Z46Oq7tLAyT0lGoFx4DOuB1IA9D1TPj0QkYxpPVUnGDqHHvDpCftu1J2hM2PiWsNMoZh8+LQaarAWcDfPBc6zg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.53.1:
+    resolution: {integrity: sha512-LJ13YLr/ocweuwxyGf1XNFWIU4M2zUSo149Qbp+A4cpwDjsxRPj7k6H25LBrEHiEwxvRbD8HdwvQmRMSvquhYw==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
@@ -4514,6 +4537,10 @@ snapshots:
   '@next/swc-win32-x64-msvc@15.3.4':
     optional: true
 
+  '@playwright/test@1.53.1':
+    dependencies:
+      playwright: 1.53.1
+
   '@pmmmwh/react-refresh-webpack-plugin@0.5.16(react-refresh@0.14.2)(type-fest@2.19.0)(webpack-hot-middleware@2.26.1)(webpack@5.99.9(esbuild@0.25.5))':
     dependencies:
       ansi-html: 0.0.9
@@ -4567,7 +4594,7 @@ snapshots:
 
   '@storybook/global@5.0.0': {}
 
-  '@storybook/nextjs@9.0.12(esbuild@0.25.5)(next@15.3.4(@babel/core@7.27.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.12(@testing-library/dom@10.4.0))(type-fest@2.19.0)(typescript@5.8.3)(webpack-hot-middleware@2.26.1)(webpack@5.99.9(esbuild@0.25.5))':
+  '@storybook/nextjs@9.0.12(esbuild@0.25.5)(next@15.3.4(@babel/core@7.27.4)(@playwright/test@1.53.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.12(@testing-library/dom@10.4.0))(type-fest@2.19.0)(typescript@5.8.3)(webpack-hot-middleware@2.26.1)(webpack@5.99.9(esbuild@0.25.5))':
     dependencies:
       '@babel/core': 7.27.4
       '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.27.4)
@@ -4591,7 +4618,7 @@ snapshots:
       css-loader: 6.11.0(webpack@5.99.9(esbuild@0.25.5))
       image-size: 2.0.2
       loader-utils: 3.3.1
-      next: 15.3.4(@babel/core@7.27.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      next: 15.3.4(@babel/core@7.27.4)(@playwright/test@1.53.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       node-polyfill-webpack-plugin: 2.0.1(webpack@5.99.9(esbuild@0.25.5))
       postcss: 8.5.6
       postcss-loader: 8.1.1(postcss@8.5.6)(typescript@5.8.3)(webpack@5.99.9(esbuild@0.25.5))
@@ -4829,10 +4856,10 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  '@vanilla-extract/next-plugin@2.4.14(next@15.3.4(@babel/core@7.27.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(webpack@5.99.9(esbuild@0.25.5))':
+  '@vanilla-extract/next-plugin@2.4.14(next@15.3.4(@babel/core@7.27.4)(@playwright/test@1.53.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(webpack@5.99.9(esbuild@0.25.5))':
     dependencies:
       '@vanilla-extract/webpack-plugin': 2.3.22(webpack@5.99.9(esbuild@0.25.5))
-      next: 15.3.4(@babel/core@7.27.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      next: 15.3.4(@babel/core@7.27.4)(@playwright/test@1.53.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -5728,6 +5755,9 @@ snapshots:
 
   fs.realpath@1.0.0: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -6170,7 +6200,7 @@ snapshots:
 
   neo-async@2.6.2: {}
 
-  next@15.3.4(@babel/core@7.27.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+  next@15.3.4(@babel/core@7.27.4)(@playwright/test@1.53.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
     dependencies:
       '@next/env': 15.3.4
       '@swc/counter': 0.1.3
@@ -6190,6 +6220,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 15.3.4
       '@next/swc-win32-arm64-msvc': 15.3.4
       '@next/swc-win32-x64-msvc': 15.3.4
+      '@playwright/test': 1.53.1
       sharp: 0.34.2
     transitivePeerDependencies:
       - '@babel/core'
@@ -6371,6 +6402,14 @@ snapshots:
       confbox: 0.1.8
       mlly: 1.7.4
       pathe: 2.0.3
+
+  playwright-core@1.53.1: {}
+
+  playwright@1.53.1:
+    dependencies:
+      playwright-core: 1.53.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   possible-typed-array-names@1.1.0: {}
 

--- a/tests/example.spec.ts
+++ b/tests/example.spec.ts
@@ -1,0 +1,8 @@
+import { expect, test } from "@playwright/test";
+
+test("About 페이지로 이동해야 합니다.", async ({ page }) => {
+  await page.goto("/");
+  await page.click("text=About");
+  await expect(page).toHaveURL("/about");
+  await expect(page.locator("h1")).toContainText("About");
+});


### PR DESCRIPTION
## 📌 Summary

 > - #46 

대표적인 E2E 테스트 도구로는 Cypress와 Playwright가 있는데요.
E2E 테스트 도구로 Playwright 세팅을 진행하였습니다.

### Cypress 대신 Playwright를 선택한 이유

1. npm 다운로드수가 Playwright가 Cypress 대비 현재 weekly 기준 약 4배 
2. Cypress 보다 더 다양한 브라우저, 모바일 지원
3. 속도 측면에서 하나의 테스트 파일 당 하나의 워커를 실행 해 병렬 처리로 속도가 빠름

(Cypress의 경우에도 병렬 테스트가 가능하나 성능 상의 이슈로 권하지 않는다고 하네요.)

[참고 문서](https://docs.cypress.io/cloud/features/smart-orchestration/parallelization#:~:text=Cypress%20can%20run%20recorded%20tests,to%20run%20your%20tests%20efficiently)


## 📚 Tasks

### Playwright 패키지 설치 및 초기 설정을 진행 하였습니다.

- `playwright.config.ts` 설정 파일 추가
- `playwright.yml` 워크플로우 추가

또한 테스트를 위해 Home과 About 페이지를 임시로 추가하고 `example.spec.ts` 를 추가해두었습니다.

  
## 👀 To Reviewer

`package.josn`의 scripts를 보시면 아시겠지만 `pnpm test:ui` 를 활용해 Playwright UI를 통해 손쉽게 테스트를 진행 할 수 있습니다.

## 📸 Screenshot
아래는 테스트 영상입니다.

https://github.com/user-attachments/assets/5f3a6969-2554-49e1-abf1-ec36b86aabd1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * "About" 페이지가 추가되어 홈에서 "About" 페이지로 이동할 수 있습니다.
  * Playwright를 활용한 E2E 테스트 환경이 도입되었습니다.

* **버그 수정**
  * 해당 없음

* **문서화**
  * 해당 없음

* **테스트**
  * "About" 페이지로의 네비게이션을 검증하는 Playwright 테스트가 추가되었습니다.

* **작업**
  * Playwright 관련 파일 및 디렉토리가 .gitignore에 추가되어 버전 관리에서 제외됩니다.
  * Playwright 테스트 실행을 위한 GitHub Actions 워크플로우가 추가되었습니다.
  * Playwright 설정 파일 및 테스트 스크립트가 추가되었습니다.
  * Playwright 테스트 실행을 위한 npm 스크립트와 의존성이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->