### PR TITLE
Feat: add capsule button 구현, useInView 훅 추가

### DIFF
--- a/shared/hooks/useInView.ts
+++ b/shared/hooks/useInView.ts
@@ -1,0 +1,43 @@
+import { useEffect, useRef, useState } from "react";
+
+/**
+ * useInView
+ *
+ * 특정 DOM 요소가 뷰포트(Viewport)에 보이는지 여부를 감지하는 커스텀 훅입니다.
+ * IntersectionObserver API를 사용합니다.
+ *
+ * @param {number} [threshold=0.2] - 요소가 뷰포트에 얼마나 보여야 isIntersecting이 true가 되는지 결정하는 값 (0~1)
+ * @returns {{
+ *   ref: React.RefObject<HTMLElement>;
+ *   isIntersecting: boolean;
+ * }} ref: 감지할 요소에 할당할 ref, isIntersecting: 뷰포트에 보이는지 여부
+ *
+ * @example
+ * const { ref, isIntersecting } = useInView(0.5);
+ *
+ * // 이때 div는 뷰포트에 보이는지 여부를 감지할 요소입니다. 뷰포트 화면 전체 넓이로 설정해야 합니다.
+ * return <div ref={ref}>{isIntersecting ? "보임" : "안 보임"}</div>;
+ */
+export const useInView = (threshold = 0.2) => {
+  const ref = useRef<HTMLDivElement>(null);
+  const [isIntersecting, setIsIntersecting] = useState(false);
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        setIsIntersecting(entry.isIntersecting);
+      },
+      { threshold },
+    );
+    if (ref.current) {
+      observer.observe(ref.current);
+    }
+    return () => {
+      if (ref.current) {
+        observer.unobserve(ref.current);
+      }
+    };
+  }, [threshold]);
+
+  return { ref, isIntersecting };
+};

--- a/shared/ui/add-capsule-button/add-capsule-button.css.ts
+++ b/shared/ui/add-capsule-button/add-capsule-button.css.ts
@@ -1,0 +1,14 @@
+import { themeVars } from "@/shared/styles/base/theme.css";
+import { style } from "@vanilla-extract/css";
+
+export const buttonStyle = style({
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  gap: "0.8rem",
+  padding: "1rem 1.9rem",
+  height: "5rem",
+  borderRadius: "16px",
+  ...themeVars.text.B1,
+  backgroundColor: themeVars.color.purple[50],
+});

--- a/shared/ui/add-capsule-button/add-capsule-button.css.ts
+++ b/shared/ui/add-capsule-button/add-capsule-button.css.ts
@@ -2,7 +2,7 @@ import { themeVars } from "@/shared/styles/base/theme.css";
 import { style } from "@vanilla-extract/css";
 
 export const buttonStyle = style({
-  display: "flex",
+  display: "inline-flex",
   alignItems: "center",
   justifyContent: "center",
   gap: "0.8rem",
@@ -11,4 +11,26 @@ export const buttonStyle = style({
   borderRadius: "16px",
   ...themeVars.text.B1,
   backgroundColor: themeVars.color.purple[50],
+  position: "fixed",
+  right: "3rem",
+  bottom: "4rem",
+  transition: "width 0.3s, padding 0.3s, gap 0.3s",
+  overflow: "hidden",
+  whiteSpace: "nowrap",
+});
+
+export const expanded = style({
+  width: "12rem",
+  padding: "1rem 1.9rem",
+  gap: "0.8rem",
+});
+
+export const collapsed = style({
+  width: "5rem",
+  padding: "1rem",
+  gap: 0,
+});
+
+export const refDiv = style({
+  height: 1,
 });

--- a/shared/ui/add-capsule-button/add-capsule-button.stories.tsx
+++ b/shared/ui/add-capsule-button/add-capsule-button.stories.tsx
@@ -1,0 +1,35 @@
+import type { Meta, StoryObj } from "@storybook/nextjs";
+import AddCapsuleButton from "./index";
+
+const meta: Meta<typeof AddCapsuleButton> = {
+  title: "UI/AddCapsuleButton",
+  component: AddCapsuleButton,
+  parameters: {
+    layout: "centered",
+    docs: {
+      description: {
+        component: "AddCapsuleButton 컴포넌트는 캡슐을 추가하는 버튼입니다.",
+      },
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div
+        style={{
+          width: "800px",
+          height: "100vh",
+          display: "flex",
+          justifyContent: "center",
+          alignItems: "center",
+        }}
+      >
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+type Story = StoryObj<typeof meta>;
+export default meta;
+
+export const Default: Story = {};

--- a/shared/ui/add-capsule-button/add-capsule-button.stories.tsx
+++ b/shared/ui/add-capsule-button/add-capsule-button.stories.tsx
@@ -7,20 +7,24 @@ const meta: Meta<typeof AddCapsuleButton> = {
   parameters: {
     layout: "centered",
     docs: {
+      disable: true,
       description: {
-        component: "AddCapsuleButton 컴포넌트는 캡슐을 추가하는 버튼입니다.",
+        component: `
+AddCapsuleButton 컴포넌트는 캡슐을 추가하는 버튼입니다.
+- IntersectionObserver API를 사용하여 스크롤을 내리면 버튼이 축소되도록 구현하였습니다.
+
+Default 탭을 클릭하여 UI를 확인해주세요.
+`,
       },
     },
   },
+  tags: ["autodocs"],
   decorators: [
     (Story) => (
       <div
         style={{
           width: "800px",
-          height: "100vh",
-          display: "flex",
-          justifyContent: "center",
-          alignItems: "center",
+          height: "2500px",
         }}
       >
         <Story />

--- a/shared/ui/add-capsule-button/index.tsx
+++ b/shared/ui/add-capsule-button/index.tsx
@@ -1,13 +1,26 @@
-import PlusIcon from "@/shared/assets/icon/plus.svg";
+"use client";
 
+import PlusIcon from "@/shared/assets/icon/plus.svg";
+import { useInView } from "@/shared/hooks/useInView";
+import { cn } from "@/shared/utils/cn";
 import * as styles from "./add-capsule-button.css";
 
 const AddCapsuleButton = () => {
+  const { ref, isIntersecting } = useInView(0.2);
+
   return (
-    <button className={styles.buttonStyle}>
-      <PlusIcon />
-      만들기
-    </button>
+    <>
+      <div ref={ref} className={styles.refDiv} />
+      <button
+        className={cn(
+          styles.buttonStyle,
+          isIntersecting ? styles.expanded : styles.collapsed,
+        )}
+      >
+        <PlusIcon />
+        {isIntersecting && "만들기"}
+      </button>
+    </>
   );
 };
 

--- a/shared/ui/add-capsule-button/index.tsx
+++ b/shared/ui/add-capsule-button/index.tsx
@@ -1,0 +1,14 @@
+import PlusIcon from "@/shared/assets/icon/plus.svg";
+
+import * as styles from "./add-capsule-button.css";
+
+const AddCapsuleButton = () => {
+  return (
+    <button className={styles.buttonStyle}>
+      <PlusIcon />
+      만들기
+    </button>
+  );
+};
+
+export default AddCapsuleButton;


### PR DESCRIPTION
## 📌 Summary

> - #81 

## 📚 Tasks

- 만들기 버튼 구현
- 만들기 버튼 스토리 작성
- useInView 훅 구현

## 👀 To Reviewer
만들기 버튼은 스크롤 다운하면 텍스트가 사라지고 넓이가 줄어드는데, 다음과 같은 흐름으로 구현했습니다.

- 감지용 div를 임의로 생성 -> IntersectionObserver API를 사용해 해당 div가 뷰포트에 진입하는지 감지 -> 설정한 비율만큼 뷰포트에 들어오면, 버튼이 줄어들도록 상태 변경

이 과정에서 dom 요소가 뷰포트에 보이는지 여부를 감지하는 커스텀 훅인 useInView를 추가했습니다. 감지할 요소에 ref를 바인딩하고, isIntersecting 값으로 뷰포트 진입 여부를 확인할 수 있습니다.

구현된 동작은 스토리북으로 확인해주세요!

<!--
## 📸 Screenshot

(기재 내용 없을 경우 섹션 삭제) 작업한 내용에 대한 스크린샷을 첨부해주세요. 필요시 .gif 형식으로 첨부해주세요.
-->
