### PR TITLE
Fix: queryClient 컨텍스트 인식 오류 해결 및 누락된 스타일 추가

### DIFF
--- a/app/(sub)/capsule-detail/[id]/page.tsx
+++ b/app/(sub)/capsule-detail/[id]/page.tsx
@@ -28,7 +28,7 @@ const CapsuleDetailPage = () => {
         renderRight={() => {
           return (
             <>
-              <LikeButton isLiked={false} />
+              <LikeButton isLiked={data?.result.isLiked || false} />
               <Dropdown>
                 <Dropdown.Trigger>
                   <MenuIcon />

--- a/app/(sub)/capsule-detail/_components/info-title/info-title.css.ts
+++ b/app/(sub)/capsule-detail/_components/info-title/info-title.css.ts
@@ -10,7 +10,7 @@ export const container = style({
   width: "100%",
   paddingTop: "2.4rem",
   ...screen.md({
-    paddingTop: "4.6rem",
+    paddingTop: "9.6rem",
   }),
 });
 

--- a/app/(sub)/create-capsule/page.tsx
+++ b/app/(sub)/create-capsule/page.tsx
@@ -21,7 +21,7 @@ const CreateCapsule = () => {
   const searchParams = useSearchParams();
   const router = useRouter();
   const currentStep = searchParams.get("step") || "intro";
-  const { mutate } = useCreateCapsule();
+  const { mutate: createCapsuleMutate } = useCreateCapsule();
 
   const form = useForm<CreateCapsuleReq>({
     defaultValues: {
@@ -38,10 +38,8 @@ const CreateCapsule = () => {
   };
 
   const onSubmit: SubmitHandler<CreateCapsuleReq> = (data) => {
-    console.log(data);
-    mutate(data, {
+    createCapsuleMutate(data, {
       onSuccess: (res) => {
-        console.log(res);
         router.push(
           PATH.CAPSULE_DETAIL.replace(":id", res.result.id.toString()),
         );

--- a/app/(sub)/create-capsule/page.tsx
+++ b/app/(sub)/create-capsule/page.tsx
@@ -40,9 +40,7 @@ const CreateCapsule = () => {
   const onSubmit: SubmitHandler<CreateCapsuleReq> = (data) => {
     createCapsuleMutate(data, {
       onSuccess: (res) => {
-        router.push(
-          PATH.CAPSULE_DETAIL.replace(":id", res.result.id.toString()),
-        );
+        router.push(`${PATH.CAPSULE_DETAIL}/${res.result.id}`);
       },
     });
   };

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -1,7 +1,6 @@
 "use client";
 import QueryProvider from "@/shared/providers/query-provider";
 import { OverlayProvider } from "overlay-kit";
-import { useEffect, useState } from "react";
 import type { ReactNode } from "react";
 
 interface ProvidersProps {
@@ -9,12 +8,6 @@ interface ProvidersProps {
 }
 
 const Providers = ({ children }: ProvidersProps) => {
-  const [isClient, setIsClient] = useState(false);
-
-  useEffect(() => setIsClient(true), []);
-
-  if (!isClient) return <>{children}</>;
-
   return (
     <QueryProvider>
       <OverlayProvider>{children}</OverlayProvider>

--- a/shared/constants/path.ts
+++ b/shared/constants/path.ts
@@ -10,5 +10,5 @@ export const PATH = {
 
   // capsule
   CREATE_CAPSULE: "/create-capsule",
-  CAPSULE_DETAIL: "/capsule-detail/:id",
+  CAPSULE_DETAIL: "/capsule-detail",
 } as const;


### PR DESCRIPTION
## 📌 Summary

## 📚 Tasks
Provider를 조건문을 통해 클라이언트에서만 감싸주었는데, 페이지 새로고침 시 useQuery를 사용하는 컴포넌트가 queryClient 컨텍스트를 찾지 못해 오류 발생.

-> Provider가 SSR과 클라이언트 양쪽 모두에 감싸주도록 수정

쿼리 provider 내부에서 서버에선 매번 새 클라이언트를 생성하고 클라이언트에선 싱글톤을 사용하도록 구현했있으므로, 모든 Provider를 분기처리해 클라에만 별도로 감싸주는건 불필요한 처리였음

## 👀 To Reviewer
버그 해결 pr이라 선 머지합니다!

<!--
## 📸 Screenshot

(기재 내용 없을 경우 섹션 삭제) 작업한 내용에 대한 스크린샷을 첨부해주세요. 필요시 .gif 형식으로 첨부해주세요.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 좋아요 버튼의 상태가 실제 데이터에 따라 동적으로 반영되도록 개선되었습니다.

* **스타일**
  * 캡슐 상세 정보 타이틀의 중간 화면 크기에서 상단 패딩이 증가되었습니다.

* **리팩터**
  * 캡슐 생성 후 상세 페이지로 이동하는 URL 생성 방식이 간소화되었습니다.
  * Providers 컴포넌트가 항상 자식 컴포넌트를 즉시 감싸도록 동작이 단순화되었습니다.

* **기타**
  * 캡슐 상세 페이지 경로에서 동적 ID 파라미터가 제거되어 정적 경로로 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->