### PR TITLE
Fix: 스타일 깨지는 부분 수정, 탐색/내캡슐 페이지 무한 스크롤 구현

### DIFF
--- a/app/(main)/explore/_components/card-container/index.tsx
+++ b/app/(main)/explore/_components/card-container/index.tsx
@@ -2,31 +2,26 @@ import Card from "@/shared/ui/card";
 
 import * as styles from "./card-container.css";
 
-import { capsuleQueryOptions } from "@/shared/api/queries/capsule";
 import { CARD_GRADIENTS } from "@/shared/constants/card";
 import { PATH } from "@/shared/constants/path";
-import type { CapsuleSortType } from "@/shared/types/api/capsule";
+import type { TimeCapsules } from "@/shared/types/api/capsule";
 import LoadingSpinner from "@/shared/ui/loading-spinner";
 import { cardStatusLabel } from "@/shared/utils/capsule-card";
-import { useQuery } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
+
 interface CardContainerProps {
-  selectedTab: string;
-  selectedSort: CapsuleSortType;
+  capsules: TimeCapsules[];
+  isLoading: boolean;
 }
 
-const CardContainer = ({ selectedTab, selectedSort }: CardContainerProps) => {
-  const { data: capsuleLists, isPending } = useQuery(
-    capsuleQueryOptions.capsuleLists(0, 20, selectedSort, selectedTab),
-  );
-
+const CardContainer = ({ capsules, isLoading }: CardContainerProps) => {
   const router = useRouter();
 
-  if (isPending) return <LoadingSpinner loading={isPending} size={20} />;
+  if (isLoading) return <LoadingSpinner loading={isLoading} size={20} />;
 
   return (
     <div className={styles.cardContainer}>
-      {capsuleLists?.result.timeCapsules.map((capsule, index) => (
+      {capsules.map((capsule, index) => (
         <Card
           key={capsule.id}
           openStatusLabel={cardStatusLabel(capsule.remainingStatus)}

--- a/app/(main)/explore/page.tsx
+++ b/app/(main)/explore/page.tsx
@@ -1,11 +1,14 @@
 "use client";
-
 import SelectTabSection from "@/app/(main)/explore/_components/select-tab-section";
 import TitleSection from "@/app/(main)/explore/_components/title-section";
 import AddCapsuleButton from "@/app/(sub)/create-capsule/_components/add-capsule-button";
+import { capsuleQueryOptions } from "@/shared/api/queries/capsule";
 import { CAPSULE_SORT, type CapsuleSortType } from "@/shared/types/api/capsule";
+import LoadingSpinner from "@/shared/ui/loading-spinner";
 import RevealMotion from "@/shared/ui/motion/reveal-motion";
+import { useInfiniteQuery } from "@tanstack/react-query";
 import { useState } from "react";
+import { useIntersectionObserver } from "react-simplikit";
 import CardContainer from "./_components/card-container";
 import Footer from "./_components/footer";
 
@@ -14,6 +17,21 @@ const Explore = () => {
   const [selectedSort, setSelectedSort] = useState<CapsuleSortType>(
     CAPSULE_SORT.DEFAULT,
   );
+
+  const footerRef = useIntersectionObserver<HTMLDivElement>(
+    (entry) => {
+      if (entry.isIntersecting && hasNextPage && !isFetchingNextPage) {
+        fetchNextPage();
+      }
+    },
+    { threshold: 1 },
+  );
+
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isPending } =
+    useInfiniteQuery(
+      capsuleQueryOptions.infiniteCapsuleLists(selectedSort, selectedTab),
+    );
+
   const handleSelect = (value: string) => {
     setSelectedTab(value);
   };
@@ -21,6 +39,9 @@ const Explore = () => {
   const handleSort = (value: CapsuleSortType) => {
     setSelectedSort(value);
   };
+
+  const allCapsules =
+    data?.pages.flatMap((page) => page.result.timeCapsules) || [];
 
   return (
     <>
@@ -33,8 +54,12 @@ const Explore = () => {
         selectedTab={selectedTab}
       />
       <AddCapsuleButton />
-      <CardContainer selectedTab={selectedTab} selectedSort={selectedSort} />
-      <Footer />
+      <CardContainer capsules={allCapsules} isLoading={isPending} />
+
+      <div ref={footerRef}>
+        <Footer />
+        {isFetchingNextPage && <LoadingSpinner loading={true} size={20} />}
+      </div>
     </>
   );
 };

--- a/app/(main)/explore/page.tsx
+++ b/app/(main)/explore/page.tsx
@@ -24,7 +24,7 @@ const Explore = () => {
         fetchNextPage();
       }
     },
-    { threshold: 1 },
+    { threshold: 0.8 },
   );
 
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isPending } =

--- a/app/(main)/my-capsule/_components/card-container/card-container.css.ts
+++ b/app/(main)/my-capsule/_components/card-container/card-container.css.ts
@@ -8,7 +8,7 @@ export const cardContainer = style({
   padding: "1.6rem",
   paddingTop: "2.3rem",
   margin: "0 auto",
-  paddingBottom: "7.2rem",
+  paddingBottom: "0rem",
   gridTemplateColumns: "repeat(2, 1fr)",
 
   // 정확한 반응형 적용하기 위해 미디어 쿼리 직접 사용

--- a/app/(main)/my-capsule/_components/card-container/index.tsx
+++ b/app/(main)/my-capsule/_components/card-container/index.tsx
@@ -1,37 +1,29 @@
 "use client";
-import { capsuleQueryOptions } from "@/shared/api/queries/capsule";
 import { CARD_GRADIENTS } from "@/shared/constants/card";
 import { PATH } from "@/shared/constants/path";
-import type {
-  CapsuleSortType,
-  MyCapsuleFilterType,
-} from "@/shared/types/api/capsule";
+import type { TimeCapsules } from "@/shared/types/api/capsule";
 import Card from "@/shared/ui/card";
 import LoadingSpinner from "@/shared/ui/loading-spinner";
 import { cardStatusLabel } from "@/shared/utils/capsule-card";
-import { useQuery } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
 import EmptySection from "../empty-section";
 import * as styles from "./card-container.css";
 
 interface CardContainerProps {
-  selectedTab: MyCapsuleFilterType;
-  selectedSort: CapsuleSortType;
+  capsules: TimeCapsules[];
+  isLoading: boolean;
 }
 
-const CardContainer = ({ selectedTab, selectedSort }: CardContainerProps) => {
+const CardContainer = ({ capsules, isLoading }: CardContainerProps) => {
   const router = useRouter();
-  const { data: capsuleLists, isPending } = useQuery(
-    capsuleQueryOptions.myCapsuleList(0, 20, selectedSort, selectedTab),
-  );
 
-  if (isPending) return <LoadingSpinner loading={isPending} size={20} />;
+  if (isLoading) return <LoadingSpinner loading={isLoading} size={20} />;
 
-  return capsuleLists?.result.timeCapsules.length === 0 ? (
-    <EmptySection />
-  ) : (
+  if (capsules.length === 0) return <EmptySection />;
+
+  return (
     <div className={styles.cardContainer}>
-      {capsuleLists?.result.timeCapsules.map((capsule, index) => (
+      {capsules.map((capsule, index) => (
         <Card
           privacy={capsule.accessType}
           key={capsule.id}

--- a/app/(main)/my-capsule/page.css.ts
+++ b/app/(main)/my-capsule/page.css.ts
@@ -1,0 +1,8 @@
+import { style } from "@vanilla-extract/css";
+
+export const footer = style({
+  display: "flex",
+  justifyContent: "center",
+  alignItems: "center",
+  height: "7.2rem",
+});

--- a/app/(main)/my-capsule/page.tsx
+++ b/app/(main)/my-capsule/page.tsx
@@ -1,16 +1,21 @@
 "use client";
-
+import { capsuleQueryOptions } from "@/shared/api/queries/capsule";
 import {
   CAPSULE_SORT,
   type CapsuleSortType,
   MY_CAPSULE_FILTER,
   type MyCapsuleFilterType,
 } from "@/shared/types/api/capsule";
+import LoadingSpinner from "@/shared/ui/loading-spinner";
 import RevealMotion from "@/shared/ui/motion/reveal-motion";
+import { useInfiniteQuery } from "@tanstack/react-query";
 import { useState } from "react";
+import { useIntersectionObserver } from "react-simplikit";
 import CardContainer from "./_components/card-container";
 import SelectTabSection from "./_components/select-tab-section";
 import TitleSection from "./_components/title-section";
+
+import * as styles from "./page.css";
 
 const MyCapsule = () => {
   const [selectedTab, setSelectedTab] = useState<MyCapsuleFilterType>(
@@ -20,6 +25,20 @@ const MyCapsule = () => {
     CAPSULE_SORT.DEFAULT,
   );
 
+  const footerRef = useIntersectionObserver<HTMLDivElement>(
+    (entry) => {
+      if (entry.isIntersecting && hasNextPage && !isFetchingNextPage) {
+        fetchNextPage();
+      }
+    },
+    { threshold: 1 },
+  );
+
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isPending } =
+    useInfiniteQuery(
+      capsuleQueryOptions.infiniteMyCapsuleList(selectedSort, selectedTab),
+    );
+
   const handleSelect = (value: MyCapsuleFilterType) => {
     setSelectedTab(value);
   };
@@ -27,6 +46,9 @@ const MyCapsule = () => {
   const handleSort = (value: CapsuleSortType) => {
     setSelectedSort(value);
   };
+
+  const allCapsules =
+    data?.pages.flatMap((page) => page.result.timeCapsules) || [];
 
   return (
     <>
@@ -38,7 +60,11 @@ const MyCapsule = () => {
         selectedTab={selectedTab}
         handleSort={handleSort}
       />
-      <CardContainer selectedTab={selectedTab} selectedSort={selectedSort} />
+      <CardContainer capsules={allCapsules} isLoading={isPending} />
+
+      <div ref={footerRef} className={styles.footer}>
+        {isFetchingNextPage && <LoadingSpinner loading={true} size={20} />}
+      </div>
     </>
   );
 };

--- a/app/(main)/my-capsule/page.tsx
+++ b/app/(main)/my-capsule/page.tsx
@@ -9,7 +9,7 @@ import {
 import LoadingSpinner from "@/shared/ui/loading-spinner";
 import RevealMotion from "@/shared/ui/motion/reveal-motion";
 import { useInfiniteQuery } from "@tanstack/react-query";
-import { useState } from "react";
+import { useCallback, useState } from "react";
 import { useIntersectionObserver } from "react-simplikit";
 import CardContainer from "./_components/card-container";
 import SelectTabSection from "./_components/select-tab-section";
@@ -25,19 +25,25 @@ const MyCapsule = () => {
     CAPSULE_SORT.DEFAULT,
   );
 
-  const footerRef = useIntersectionObserver<HTMLDivElement>(
-    (entry) => {
-      if (entry.isIntersecting && hasNextPage && !isFetchingNextPage) {
-        fetchNextPage();
-      }
-    },
-    { threshold: 1 },
-  );
-
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isPending } =
     useInfiniteQuery(
       capsuleQueryOptions.infiniteMyCapsuleList(selectedSort, selectedTab),
     );
+
+  const onIntersect = useCallback(
+    (entry: IntersectionObserverEntry) => {
+      if (!entry.isIntersecting) return;
+      if (hasNextPage && !isFetchingNextPage) {
+        fetchNextPage();
+      }
+    },
+    [hasNextPage, isFetchingNextPage, fetchNextPage],
+  );
+
+  const footerRef = useIntersectionObserver<HTMLDivElement>(onIntersect, {
+    threshold: 0.1,
+    rootMargin: "100px 0px",
+  });
 
   const handleSelect = (value: MyCapsuleFilterType) => {
     setSelectedTab(value);

--- a/app/(sub)/capsule-detail/[invite-code]/[id]/page.tsx
+++ b/app/(sub)/capsule-detail/[invite-code]/[id]/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+
 import { useLikeToggle } from "@/shared/api/mutations/capsule";
 import { capsuleQueryOptions } from "@/shared/api/queries/capsule";
 import MenuIcon from "@/shared/assets/icon/menu.svg";
@@ -6,6 +7,7 @@ import { PATH } from "@/shared/constants/path";
 import Dropdown from "@/shared/ui/dropdown";
 import InfoToast from "@/shared/ui/info-toast";
 import LikeButton from "@/shared/ui/like-button";
+import LoadingSpinner from "@/shared/ui/loading-spinner";
 import RevealMotion from "@/shared/ui/motion/reveal-motion";
 import NavbarDetail from "@/shared/ui/navbar/navbar-detail";
 import PopupReport from "@/shared/ui/popup/popup-report";
@@ -30,7 +32,7 @@ const CapsuleDetailPage = () => {
   );
 
   if (isLoading) {
-    return <div>Loading...</div>;
+    return <LoadingSpinner loading={true} size={20} />;
   }
 
   if (!data || isError) {

--- a/app/(sub)/create-capsule/_components/steps/date-step/capsule-open-at-input/capsule-open-at-input.css.ts
+++ b/app/(sub)/create-capsule/_components/steps/date-step/capsule-open-at-input/capsule-open-at-input.css.ts
@@ -35,9 +35,8 @@ export const inputStyle = style({
   borderRadius: "12px",
   width: "100%",
   height: "5rem",
-  padding: "0 0.5rem",
+  padding: "0 2rem",
   ...screen.md({
-    padding: "0 2rem",
     ...themeVars.text.F17,
   }),
   selectors: {

--- a/app/(sub)/create-capsule/_components/steps/date-step/letter-close-at-input/letter-close-at-input.css.ts
+++ b/app/(sub)/create-capsule/_components/steps/date-step/letter-close-at-input/letter-close-at-input.css.ts
@@ -44,9 +44,8 @@ export const inputStyle = style({
   borderRadius: "12px",
   width: "100%",
   height: "5rem",
-  padding: "0 0.5rem",
+  padding: "0 2rem",
   ...screen.md({
-    padding: "0 2rem",
     ...themeVars.text.F17,
   }),
   selectors: {

--- a/middleware.ts
+++ b/middleware.ts
@@ -19,17 +19,6 @@ const getAccessToken = (request: NextRequest): string | undefined => {
   return request.cookies.get("accessToken")?.value;
 };
 
-// 토큰 만료 확인 함수
-const isTokenExpired = (token: string): boolean => {
-  try {
-    const payload = JSON.parse(atob(token.split(".")[1]));
-    const currentTime = Math.floor(Date.now() / 1000);
-    return payload.exp < currentTime;
-  } catch {
-    return true;
-  }
-};
-
 export async function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
 
@@ -49,17 +38,6 @@ export async function middleware(request: NextRequest) {
     const originalUrl = request.nextUrl.pathname + request.nextUrl.search;
     loginUrl.searchParams.set("next", originalUrl);
     return NextResponse.redirect(loginUrl);
-  }
-
-  if (isTokenExpired(accessToken)) {
-    // 만료된 토큰 쿠키 삭제 후 로그인 페이지로 리다이렉트
-    const loginUrl = new URL("/login", request.url);
-    const originalUrl = request.nextUrl.pathname + request.nextUrl.search;
-    loginUrl.searchParams.set("next", originalUrl);
-
-    const response = NextResponse.redirect(loginUrl);
-    response.cookies.delete("accessToken");
-    return response;
   }
 
   return NextResponse.next();

--- a/next.config.ts
+++ b/next.config.ts
@@ -33,7 +33,7 @@ const baseConfig: NextConfig = {
     return [
       {
         source: "/api/:path*",
-        destination: "https://lettie.me/api/:path*",
+        destination: "https://api-dev.lettie.me/api/:path*",
       },
     ];
   },

--- a/shared/api/queries/capsule.ts
+++ b/shared/api/queries/capsule.ts
@@ -1,4 +1,4 @@
-import { queryOptions } from "@tanstack/react-query";
+import { infiniteQueryOptions, queryOptions } from "@tanstack/react-query";
 
 import { ENDPOINTS } from "@/shared/constants/endpoints";
 
@@ -8,6 +8,7 @@ import type {
   CapsuleSortType,
   MyCapsuleFilterType,
 } from "@/shared/types/api/capsule";
+
 import { apiClient } from "../api-client";
 
 export const capsuleQueryKeys = {
@@ -19,12 +20,24 @@ export const capsuleQueryKeys = {
     sort?: CapsuleSortType,
     type?: string,
   ) => [...capsuleQueryKeys.all(), "lists", page, size, sort, type],
+  infiniteLists: (sort?: CapsuleSortType, type?: string) => [
+    ...capsuleQueryKeys.all(),
+    "infiniteLists",
+    sort,
+    type,
+  ],
   my: (
     page?: number,
     size?: number,
     sort?: CapsuleSortType,
     filter?: MyCapsuleFilterType,
   ) => [...capsuleQueryKeys.all(), "my", page, size, sort, filter],
+  infiniteMy: (sort?: CapsuleSortType, filter?: MyCapsuleFilterType) => [
+    ...capsuleQueryKeys.all(),
+    "infiniteMy",
+    sort,
+    filter,
+  ],
 } as const;
 
 export const capsuleQueryOptions = {
@@ -44,6 +57,17 @@ export const capsuleQueryOptions = {
       queryKey: capsuleQueryKeys.lists(page, size, sort, type),
       queryFn: () => getCapsuleLists(page, size, sort, type),
     }),
+  infiniteCapsuleLists: (sort?: CapsuleSortType, type?: string) =>
+    infiniteQueryOptions({
+      queryKey: capsuleQueryKeys.infiniteLists(sort, type),
+      queryFn: ({ pageParam = 0 }) =>
+        getCapsuleLists(pageParam, 20, sort, type),
+      getNextPageParam: (lastPage) => {
+        const { pageNumber, totalPages } = lastPage.result;
+        return pageNumber < totalPages - 1 ? pageNumber + 1 : undefined;
+      },
+      initialPageParam: 0,
+    }),
   myCapsuleList: (
     page?: number,
     size?: number,
@@ -53,6 +77,20 @@ export const capsuleQueryOptions = {
     queryOptions({
       queryKey: capsuleQueryKeys.my(page, size, sort, filter),
       queryFn: () => getMyCapsuleList(page, size, sort, filter),
+    }),
+  infiniteMyCapsuleList: (
+    sort?: CapsuleSortType,
+    filter?: MyCapsuleFilterType,
+  ) =>
+    infiniteQueryOptions({
+      queryKey: capsuleQueryKeys.infiniteMy(sort, filter),
+      queryFn: ({ pageParam = 0 }) =>
+        getMyCapsuleList(pageParam, 20, sort, filter),
+      getNextPageParam: (lastPage) => {
+        const { pageNumber, totalPages } = lastPage.result;
+        return pageNumber < totalPages - 1 ? pageNumber + 1 : undefined;
+      },
+      initialPageParam: 0,
     }),
 } as const;
 

--- a/shared/styles/base/global.css.ts
+++ b/shared/styles/base/global.css.ts
@@ -24,6 +24,12 @@ globalStyle('input[type="date"]', {
   MozAppearance: "none",
 });
 
+globalStyle('input[type="time"]', {
+  appearance: "none",
+  WebkitAppearance: "none",
+  MozAppearance: "none",
+});
+
 export const rootStyle = style({
   display: "flex",
   flexDirection: "column",

--- a/shared/ui/loading-spinner/loading-spinner.css.ts
+++ b/shared/ui/loading-spinner/loading-spinner.css.ts
@@ -5,4 +5,5 @@ export const wrapper = style({
   justifyContent: "center",
   alignItems: "center",
   width: "100%",
+  height: "20%",
 });


### PR DESCRIPTION
## 📌 Summary

> - #152 


## 📚 Tasks

- 캡슐만들기 시간 선택하는 input 사파리에서 스타일 깨지는 부분 수정
- 탐색/내캡슐 페이지 무한 스크롤 구현


## 👀 To Reviewer
페이지 컴포넌트에서 infiniteQuery 호출하고, footer가 뷰포트에 들어오면 다음 데이터 받아오도록 구현했습니다. CardContainer에는 받아온 데이터 넘겨주기만 합니다.
simplikit의 뷰포트 들어오면 콜백 함수 실행하는 훅 사용하니 아주 편리하더군요,,,

<!--
## 📸 Screenshot

(기재 내용 없을 경우 섹션 삭제) 작업한 내용에 대한 스크린샷을 첨부해주세요. 필요시 .gif 형식으로 첨부해주세요.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신규 기능
  - 탐색 및 내 캡슐 목록에 무한 스크롤 도입으로 연속 로딩 지원

- 리팩터
  - 카드 리스트 컴포넌트가 외부에서 전달된 데이터와 로딩 상태를 사용하도록 단순화

- 스타일
  - 시간 입력 기본 브라우저 스타일 제거
  - 입력 패딩 조정 및 카드 컨테이너 하단 패딩 제거
  - 하단 로딩 영역(푸터) 스타일 추가 및 로딩 스피너 영역 높이 조정

- 기타(chore)
  - API 프록시 도메인을 개발 도메인으로 변경
  - 만료된 토큰 시 자동 로그아웃 로직 제거

- 기타 UI
  - 상세 페이지의 로딩 텍스트를 로딩 스피너로 교체
<!-- end of auto-generated comment: release notes by coderabbit.ai -->