### PR TITLE
Fix: 비로그인 유저 좋아요 제한

### DIFF
--- a/app/(auth)/_api/auth.api.ts
+++ b/app/(auth)/_api/auth.api.ts
@@ -10,14 +10,17 @@ const AUTH_ENDPOINTS = {
 const AUTH_REDIRECT_URL = (provider: "naver" | "google") =>
   `${process.env.NEXT_PUBLIC_REDIRECT_URL}/${provider}`;
 
-export const getOAuthUrl = async (provider: "naver" | "google") => {
+export const getOAuthUrl = async (
+  provider: "naver" | "google",
+  next?: string,
+) => {
+  const redirectUrl = new URL(AUTH_REDIRECT_URL(provider));
+  if (next) {
+    redirectUrl.searchParams.set("next", next);
+  }
   const response = await apiClient.get<OAuthRes>(
     AUTH_ENDPOINTS.OAUTH_URL(provider),
-    {
-      searchParams: {
-        redirectUrl: AUTH_REDIRECT_URL(provider),
-      },
-    },
+    { searchParams: { redirectUrl: redirectUrl.toString() } },
   );
   return response.result.url;
 };

--- a/app/(auth)/login/callback/[provider]/page.tsx
+++ b/app/(auth)/login/callback/[provider]/page.tsx
@@ -14,19 +14,19 @@ export default function CallbackPage() {
   const { mutate, isPending, isError } = useSocialLogin();
 
   useEffect(() => {
-    if (!code || !provider) return;
+    if (!(code && provider)) return;
 
     mutate(
       { provider: provider, code: code },
       {
         onSuccess: () => {
-          // next 파라미터가 있으면 해당 페이지로, 없으면 홈으로
-          const redirectUrl = nextUrl || "/";
+          const redirectUrl =
+            nextUrl?.startsWith("/") && !nextUrl.startsWith("//")
+              ? nextUrl
+              : "/";
           router.replace(redirectUrl);
         },
-        onError: () => {
-          console.log("로그인 실패");
-        },
+        onError: () => {},
       },
     );
   }, [code, provider, nextUrl]);

--- a/app/(auth)/login/callback/[provider]/page.tsx
+++ b/app/(auth)/login/callback/[provider]/page.tsx
@@ -8,6 +8,7 @@ export default function CallbackPage() {
   const searchParams = useSearchParams();
   const params = useParams();
   const code = searchParams.get("code");
+  const nextUrl = searchParams.get("next");
   const provider = params.provider as "naver" | "google";
   const router = useRouter();
   const { mutate, isPending, isError } = useSocialLogin();
@@ -19,14 +20,16 @@ export default function CallbackPage() {
       { provider: provider, code: code },
       {
         onSuccess: () => {
-          router.replace("/");
+          // next 파라미터가 있으면 해당 페이지로, 없으면 홈으로
+          const redirectUrl = nextUrl || "/";
+          router.replace(redirectUrl);
         },
         onError: () => {
           console.log("로그인 실패");
         },
       },
     );
-  }, [code, provider]);
+  }, [code, provider, nextUrl]);
 
   if (isPending) return <LoadingSpinner loading={isPending} />;
 

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -8,13 +8,22 @@ import { PATH } from "@/shared/constants/path";
 import { maxWidth } from "@/shared/styles/base/global.css";
 import Image from "next/image";
 import Link from "next/link";
+import { useSearchParams } from "next/navigation";
 import { getOAuthUrl } from "../_api/auth.api";
 import * as styles from "./page.css";
 
 const LoginPage = () => {
+  const searchParams = useSearchParams();
+  const nextUrl = searchParams.get("next");
+
   const handleGoToOAuth = (provider: "naver" | "google") => {
     getOAuthUrl(provider).then((url) => {
-      window.location.href = url;
+      // next 파라미터가 있으면 OAuth URL에 추가
+      const oauthUrl = new URL(url);
+      if (nextUrl) {
+        oauthUrl.searchParams.set("next", nextUrl);
+      }
+      window.location.href = oauthUrl.toString();
     });
   };
 

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -17,13 +17,12 @@ const LoginPage = () => {
   const nextUrl = searchParams.get("next");
 
   const handleGoToOAuth = (provider: "naver" | "google") => {
-    getOAuthUrl(provider).then((url) => {
-      // next 파라미터가 있으면 OAuth URL에 추가
-      const oauthUrl = new URL(url);
-      if (nextUrl) {
-        oauthUrl.searchParams.set("next", nextUrl);
-      }
-      window.location.href = oauthUrl.toString();
+    const safeNext =
+      nextUrl?.startsWith("/") && !nextUrl.startsWith("//")
+        ? nextUrl
+        : undefined;
+    getOAuthUrl(provider, safeNext).then((url) => {
+      window.location.href = url;
     });
   };
 

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -4,11 +4,11 @@ import LettieImage from "@/shared/assets/character/lettie_animate.png";
 import GoogleIcon from "@/shared/assets/icon/google.svg";
 import NaverIcon from "@/shared/assets/icon/naver.svg";
 import LogoImage from "@/shared/assets/logo/logo_symbol_wordmark.svg";
+import { PATH } from "@/shared/constants/path";
 import { maxWidth } from "@/shared/styles/base/global.css";
-import { getOAuthUrl } from "../_api/auth.api";
-
 import Image from "next/image";
-
+import Link from "next/link";
+import { getOAuthUrl } from "../_api/auth.api";
 import * as styles from "./page.css";
 
 const LoginPage = () => {
@@ -21,7 +21,9 @@ const LoginPage = () => {
   return (
     <div className={maxWidth}>
       <header className={styles.header}>
-        <LogoImage />
+        <Link href={PATH.HOME}>
+          <LogoImage />
+        </Link>
       </header>
       <div className={styles.contentsContainer}>
         <h1 className={styles.title}>

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -1,17 +1,17 @@
 "use client";
-
 import LettieImage from "@/shared/assets/character/lettie_animate.png";
 import GoogleIcon from "@/shared/assets/icon/google.svg";
 import NaverIcon from "@/shared/assets/icon/naver.svg";
 import LogoImage from "@/shared/assets/logo/logo_symbol_wordmark.svg";
 import { PATH } from "@/shared/constants/path";
 import { maxWidth } from "@/shared/styles/base/global.css";
+import LoadingSpinner from "@/shared/ui/loading-spinner";
 import Image from "next/image";
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
+import { Suspense } from "react";
 import { getOAuthUrl } from "../_api/auth.api";
 import * as styles from "./page.css";
-
 const LoginPage = () => {
   const searchParams = useSearchParams();
   const nextUrl = searchParams.get("next");
@@ -66,4 +66,10 @@ const LoginPage = () => {
   );
 };
 
-export default LoginPage;
+export default function Page() {
+  return (
+    <Suspense fallback={<LoadingSpinner loading={true} />}>
+      <LoginPage />
+    </Suspense>
+  );
+}

--- a/app/(main)/my-capsule/_components/select-tab-section/select-tab-section.css.ts
+++ b/app/(main)/my-capsule/_components/select-tab-section/select-tab-section.css.ts
@@ -20,11 +20,12 @@ export const chipWrapper = style({
 
 export const dropdown = style({
   position: "absolute",
-  right: 0,
-  top: 0,
+  right: "0",
+  top: "100%",
+  transform: "translateY(-180%)",
   marginRight: "1rem",
   ...screen.md({
-    top: 0,
-    right: 0,
+    top: "100%",
+    transform: "translateY(-90%)",
   }),
 });

--- a/app/(sub)/capsule-detail/[invite-code]/[id]/letters/_components/grid-layout/index.tsx
+++ b/app/(sub)/capsule-detail/[invite-code]/[id]/letters/_components/grid-layout/index.tsx
@@ -12,8 +12,16 @@ const GridLayout = ({ letters, imageUrls }: GridLayoutProps) => {
     <div className={styles.container}>
       <div className={styles.grid}>
         {letters.map((letter) => {
-          const imageUrl = imageUrls.find((img) => img.letterId === letter.letterId)?.url;
-          return <GridLetterCard key={letter.letterId} letter={letter} imageUrl={imageUrl} />;
+          const imageUrl = imageUrls.find(
+            (img) => img.letterId === letter.letterId,
+          )?.url;
+          return (
+            <GridLetterCard
+              key={letter.letterId}
+              letter={letter}
+              imageUrl={imageUrl}
+            />
+          );
         })}
       </div>
     </div>

--- a/app/(sub)/capsule-detail/[invite-code]/[id]/letters/_components/grid-letter-card/index.tsx
+++ b/app/(sub)/capsule-detail/[invite-code]/[id]/letters/_components/grid-letter-card/index.tsx
@@ -13,8 +13,18 @@ const GridLetterCard = ({ letter, imageUrl, onClick }: LetterCardProps) => {
   return (
     <HoverMotion>
       <section className={styles.card} onClick={onClick}>
-        {imageUrl && <Image width={200} height={200} className={styles.image} src={imageUrl} alt="편지 이미지" />}
-        <div className={styles.content}>{!imageUrl && <p>{letter.content}</p>}</div>
+        {imageUrl && (
+          <Image
+            width={200}
+            height={200}
+            className={styles.image}
+            src={imageUrl}
+            alt="편지 이미지"
+          />
+        )}
+        <div className={styles.content}>
+          {!imageUrl && <p>{letter.content}</p>}
+        </div>
 
         {letter.from && (
           <p>

--- a/app/(sub)/capsule-detail/[invite-code]/[id]/letters/_components/open-capsule-loading/index.tsx
+++ b/app/(sub)/capsule-detail/[invite-code]/[id]/letters/_components/open-capsule-loading/index.tsx
@@ -12,7 +12,11 @@ interface OpenCapsuleLoadingProps {
 
 const AUTO_CLOSE_DELAY = 3000;
 
-const OpenCapsuleLoading = ({ participantCount, letterCount, onComplete }: OpenCapsuleLoadingProps) => {
+const OpenCapsuleLoading = ({
+  participantCount,
+  letterCount,
+  onComplete,
+}: OpenCapsuleLoadingProps) => {
   const timeoutRef = useRef<NodeJS.Timeout | null>(null);
   const isCompletedRef = useRef(false);
 

--- a/app/(sub)/capsule-detail/[invite-code]/[id]/letters/_components/stack-layout/animations.ts
+++ b/app/(sub)/capsule-detail/[invite-code]/[id]/letters/_components/stack-layout/animations.ts
@@ -4,7 +4,10 @@ const getRotateAngle = (stackIndex: number) => {
   return stackIndex * -5;
 };
 
-export const createStackAnimations = (direction: number, visibleLetters: VisibleLetter[]) => {
+export const createStackAnimations = (
+  direction: number,
+  visibleLetters: VisibleLetter[],
+) => {
   return visibleLetters.map(({ stackIndex }) => ({
     initial:
       direction === -1 && stackIndex === 0

--- a/app/(sub)/capsule-detail/[invite-code]/[id]/letters/_components/stack-layout/index.tsx
+++ b/app/(sub)/capsule-detail/[invite-code]/[id]/letters/_components/stack-layout/index.tsx
@@ -104,8 +104,13 @@ const StackLayout = ({ letters, imageUrls }: StackLayoutProps) => {
       <div className={styles.stackContainer}>
         <AnimatePresence mode="popLayout">
           {visibleLetters.map(({ letter, key }, index) => {
-            const animationProps = createStackAnimations(direction, visibleLetters)[index];
-            const imageUrl = imageUrls.find((img) => img.letterId === letter.letterId)?.url;
+            const animationProps = createStackAnimations(
+              direction,
+              visibleLetters,
+            )[index];
+            const imageUrl = imageUrls.find(
+              (img) => img.letterId === letter.letterId,
+            )?.url;
 
             return (
               <motion.div
@@ -129,7 +134,9 @@ const StackLayout = ({ letters, imageUrls }: StackLayoutProps) => {
         className={styles.navButton}
         onClick={nextLetter}
         disabled={isAnimating}
-        style={{ visibility: currentIndex < letters.length - 1 ? "visible" : "hidden" }}
+        style={{
+          visibility: currentIndex < letters.length - 1 ? "visible" : "hidden",
+        }}
         type="button"
       >
         <Right width={24} height={24} />

--- a/app/(sub)/capsule-detail/[invite-code]/[id]/letters/_components/stack-letter-card/index.tsx
+++ b/app/(sub)/capsule-detail/[invite-code]/[id]/letters/_components/stack-letter-card/index.tsx
@@ -12,8 +12,22 @@ const StackLetterCard = ({ letter, imageUrl, onClick }: LetterCardProps) => {
   return (
     <section className={styles.card} onClick={onClick}>
       <div className={styles.contentWrapper}>
-        {imageUrl && <Image width={240} height={240} className={styles.image} src={imageUrl} alt="편지 이미지" />}
-        <p className={imageUrl ? styles.contentWithImage : styles.contentWithoutImage}>{letter.content}</p>
+        {imageUrl && (
+          <Image
+            width={240}
+            height={240}
+            className={styles.image}
+            src={imageUrl}
+            alt="편지 이미지"
+          />
+        )}
+        <p
+          className={
+            imageUrl ? styles.contentWithImage : styles.contentWithoutImage
+          }
+        >
+          {letter.content}
+        </p>
       </div>
 
       {letter.from && (

--- a/app/(sub)/capsule-detail/[invite-code]/[id]/letters/page.tsx
+++ b/app/(sub)/capsule-detail/[invite-code]/[id]/letters/page.tsx
@@ -30,7 +30,9 @@ const CapsuleLettersPage = () => {
     }),
   });
 
-  const { data: letterData, isLoading: isLetterLoading } = useQuery(letterQueryOptions.letterList(capsuleId));
+  const { data: letterData, isLoading: isLetterLoading } = useQuery(
+    letterQueryOptions.letterList(capsuleId),
+  );
   const letters = letterData?.result?.letters || [];
   const { imageUrls, isImageLoading } = useLetterImages(letters);
 

--- a/app/(sub)/capsule-detail/[invite-code]/[id]/page.tsx
+++ b/app/(sub)/capsule-detail/[invite-code]/[id]/page.tsx
@@ -108,7 +108,6 @@ const CapsuleDetailPage = () => {
       <ResponsiveFooter
         remainingTime={{ days, hours, minutes, openDate }}
         status={result.status}
-        isMine={result.isMine}
       />
       {result.status !== "WRITABLE" && <InfoToast status={result.status} />}
     </>

--- a/app/(sub)/capsule-detail/[invite-code]/[id]/page.tsx
+++ b/app/(sub)/capsule-detail/[invite-code]/[id]/page.tsx
@@ -1,5 +1,4 @@
 "use client";
-
 import { useLikeToggle } from "@/shared/api/mutations/capsule";
 import { capsuleQueryOptions } from "@/shared/api/queries/capsule";
 import MenuIcon from "@/shared/assets/icon/menu.svg";
@@ -11,9 +10,11 @@ import LoadingSpinner from "@/shared/ui/loading-spinner";
 import RevealMotion from "@/shared/ui/motion/reveal-motion";
 import NavbarDetail from "@/shared/ui/navbar/navbar-detail";
 import PopupReport from "@/shared/ui/popup/popup-report";
+import { getAccessToken } from "@/shared/utils/auth";
 import { formatDateTime } from "@/shared/utils/date";
 import { useQuery } from "@tanstack/react-query";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { useParams } from "next/navigation";
 import { overlay } from "overlay-kit";
 import CapsuleImage from "../../_components/capsule-image";
@@ -30,6 +31,8 @@ const CapsuleDetailPage = () => {
   const { data, isLoading, isError } = useQuery(
     capsuleQueryOptions.capsuleDetail(id),
   );
+  const isLoggedIn = !!getAccessToken();
+  const router = useRouter();
 
   if (isLoading) {
     return <LoadingSpinner loading={true} size={20} />;
@@ -43,6 +46,10 @@ const CapsuleDetailPage = () => {
   const { days, hours, minutes, openDate } = result.remainingTime;
 
   const handleLikeToggle = (nextLiked: boolean) => {
+    if (!isLoggedIn) {
+      router.push(PATH.LOGIN);
+      return;
+    }
     likeToggle({ id: result.id.toString(), isLiked: nextLiked });
   };
 

--- a/app/(sub)/capsule-detail/[invite-code]/[id]/page.tsx
+++ b/app/(sub)/capsule-detail/[invite-code]/[id]/page.tsx
@@ -15,7 +15,7 @@ import { formatDateTime } from "@/shared/utils/date";
 import { useQuery } from "@tanstack/react-query";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { useParams } from "next/navigation";
+import { useParams, usePathname, useSearchParams } from "next/navigation";
 import { overlay } from "overlay-kit";
 import CapsuleImage from "../../_components/capsule-image";
 import CaptionSection from "../../_components/caption-section";
@@ -33,6 +33,8 @@ const CapsuleDetailPage = () => {
   );
   const isLoggedIn = !!getAccessToken();
   const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
 
   if (isLoading) {
     return <LoadingSpinner loading={true} size={20} />;
@@ -47,7 +49,9 @@ const CapsuleDetailPage = () => {
 
   const handleLikeToggle = (nextLiked: boolean) => {
     if (!isLoggedIn) {
-      router.push(PATH.LOGIN);
+      const current = `${pathname}${searchParams?.toString() ? `?${searchParams.toString()}` : ""}`;
+      const loginUrl = `${PATH.LOGIN}?next=${encodeURIComponent(current)}`;
+      router.push(loginUrl);
       return;
     }
     likeToggle({ id: result.id.toString(), isLiked: nextLiked });

--- a/app/(sub)/capsule-detail/_components/responsive-footer/index.tsx
+++ b/app/(sub)/capsule-detail/_components/responsive-footer/index.tsx
@@ -1,22 +1,21 @@
 "use client";
-import { usePathname, useRouter } from "next/navigation";
-import { useState } from "react";
-
 import CheckIcon from "@/shared/assets/icon/check.svg";
 import ShareIcon from "@/shared/assets/icon/share.svg";
 import Button from "@/shared/ui/button";
 import Chip from "@/shared/ui/chip";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useState } from "react";
 
 import WriteModal from "../write-modal";
 
 import ShakeYMotion from "@/shared/ui/motion/shakeY-motion";
 import { overlay } from "overlay-kit";
 
+import { PATH } from "@/shared/constants/path";
 import type { CapsuleStatus } from "@/shared/types/api/capsule";
 import { getAccessToken } from "@/shared/utils/auth";
 import { formatOpenDate } from "@/shared/utils/date";
 import * as styles from "./responsive-footer.css";
-
 interface Props {
   remainingTime: {
     days: number;
@@ -25,14 +24,14 @@ interface Props {
     openDate: string;
   };
   status: CapsuleStatus;
-  isMine?: boolean;
 }
 
-const ResponsiveFooter = ({ remainingTime, status, isMine }: Props) => {
+const ResponsiveFooter = ({ remainingTime, status }: Props) => {
   const [isCopied, setIsCopied] = useState(false);
   const router = useRouter();
   const pathname = usePathname();
   const isLoggedIn = !!getAccessToken();
+  const searchParams = useSearchParams();
 
   const handleClickShareButton = () => {
     navigator.clipboard.writeText(window.location.href);
@@ -44,12 +43,19 @@ const ResponsiveFooter = ({ remainingTime, status, isMine }: Props) => {
 
   const handleWriteButtonClick = () => {
     if (!isLoggedIn) {
-      router.push("/login");
+      const current = `${pathname}${searchParams?.toString() ? `?${searchParams.toString()}` : ""}`;
+      const loginUrl = `${PATH.LOGIN}?next=${encodeURIComponent(current)}`;
+      router.push(loginUrl);
       return;
     }
 
     overlay.open(({ isOpen, close }) => (
-      <WriteModal capsuleTitle="비 오는 날의 타임캡슐" isOpen={isOpen} onClose={close} remainingTime={remainingTime} />
+      <WriteModal
+        capsuleTitle="비 오는 날의 타임캡슐"
+        isOpen={isOpen}
+        onClose={close}
+        remainingTime={remainingTime}
+      />
     ));
   };
 
@@ -59,9 +65,19 @@ const ResponsiveFooter = ({ remainingTime, status, isMine }: Props) => {
 
   const renderButtons = () => {
     const shareButton = isCopied ? (
-      <Button variant="secondary" text="링크 복사됨" icon={<CheckIcon />} onClick={handleClickShareButton} />
+      <Button
+        variant="secondary"
+        text="링크 복사됨"
+        icon={<CheckIcon />}
+        onClick={handleClickShareButton}
+      />
     ) : (
-      <Button variant="secondary" text="공유하기" icon={<ShareIcon />} onClick={handleClickShareButton} />
+      <Button
+        variant="secondary"
+        text="공유하기"
+        icon={<ShareIcon />}
+        onClick={handleClickShareButton}
+      />
     );
 
     switch (status) {
@@ -69,7 +85,11 @@ const ResponsiveFooter = ({ remainingTime, status, isMine }: Props) => {
         return (
           <>
             {shareButton}
-            <Button variant="primary" text="편지 담기" onClick={handleWriteButtonClick} />
+            <Button
+              variant="primary"
+              text="편지 담기"
+              onClick={handleWriteButtonClick}
+            />
           </>
         );
       case "WAITING_OPEN":
@@ -78,7 +98,11 @@ const ResponsiveFooter = ({ remainingTime, status, isMine }: Props) => {
         return (
           <>
             {shareButton}
-            <Button variant="primary" text="캡슐 열기" onClick={handleOpenCapsuleClick} />
+            <Button
+              variant="primary"
+              text="캡슐 열기"
+              onClick={handleOpenCapsuleClick}
+            />
           </>
         );
       default:

--- a/app/(sub)/capsule-detail/_components/write-modal/index.tsx
+++ b/app/(sub)/capsule-detail/_components/write-modal/index.tsx
@@ -57,7 +57,6 @@ const WriteModal = ({
     input.onchange = (e) => {
       const file = (e.target as HTMLInputElement).files?.[0];
       if (file) {
-        console.log("Selected file:", file);
         // 파일 처리 로직 추가
       }
     };

--- a/app/(sub)/create-capsule/_components/steps/date-step/index.tsx
+++ b/app/(sub)/create-capsule/_components/steps/date-step/index.tsx
@@ -18,7 +18,7 @@ const DateStep = ({ handleNextStep }: Props) => {
   const handleNextClick = () => {
     const openDate = getValues("openDate") as string;
     const closedAt = getValues("closedAt") as string;
-    if (!openDate || !closedAt) {
+    if (!(openDate && closedAt)) {
       alert("날짜를 입력해주세요.");
       return;
     }

--- a/app/(sub)/create-capsule/_components/steps/intro-step/index.tsx
+++ b/app/(sub)/create-capsule/_components/steps/intro-step/index.tsx
@@ -18,7 +18,7 @@ const IntroStep = ({ handleNextStep }: Props) => {
 
   const handleClickNext = () => {
     const title = getValues("title");
-    if (!title || !title.trim()) {
+    if (!title?.trim()) {
       alert("타임캡슐 이름을 입력해주세요.");
       return;
     }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -11,6 +11,7 @@ import SprinkleContainer from "@/shared/ui/sprinkle-container";
 
 // TODO: 추후 수정
 export const metadata: Metadata = {
+  metadataBase: new URL("https://lettie.me"),
   icons: {
     icon: "/icon.svg",
   },

--- a/shared/constants/path.ts
+++ b/shared/constants/path.ts
@@ -5,7 +5,7 @@ export const PATH = {
   MY_CAPSULE: "/my-capsule",
   SETTING: "/setting",
   SEARCH: "/search",
-
+  LOGIN: "/login",
   // capsule
   CREATE_CAPSULE: "/create-capsule",
   CAPSULE_DETAIL: (inviteCode: string, id: string) =>

--- a/shared/hooks/use-click-outside.ts
+++ b/shared/hooks/use-click-outside.ts
@@ -6,7 +6,7 @@ const useClickOutside = (
   enable = true,
 ) => {
   useEffect(() => {
-    if (!enable || !ref.current) return;
+    if (!(enable && ref.current)) return;
     const handleClickOutside = (event: MouseEvent | TouchEvent) => {
       if (ref.current && !ref.current.contains(event.target as Node)) {
         callback();

--- a/shared/types/api/capsule.ts
+++ b/shared/types/api/capsule.ts
@@ -87,4 +87,5 @@ export const MY_CAPSULE_FILTER = {
   PARTICIPATING: "PARTICIPATING",
 } as const;
 
-export type MyCapsuleFilterType = (typeof MY_CAPSULE_FILTER)[keyof typeof MY_CAPSULE_FILTER];
+export type MyCapsuleFilterType =
+  (typeof MY_CAPSULE_FILTER)[keyof typeof MY_CAPSULE_FILTER];

--- a/shared/types/env.d.ts
+++ b/shared/types/env.d.ts
@@ -1,10 +1,6 @@
 declare global {
-  namespace NodeJS {
-    interface ProcessEnv {
-      NEXT_PUBLIC_API_BASE_URL: string;
-      NEXT_PUBLIC_REDIRECT_URL: string;
-    }
+  interface ProcessEnv {
+    NEXT_PUBLIC_API_BASE_URL: string;
+    NEXT_PUBLIC_REDIRECT_URL: string;
   }
 }
-
-export {};

--- a/shared/ui/info-toast/info-toast.css.ts
+++ b/shared/ui/info-toast/info-toast.css.ts
@@ -30,6 +30,7 @@ export const container = style({
   ...screen.md({
     bottom: "16.7rem",
   }),
+  whiteSpace: "nowrap",
 });
 
 export const checkIcon = style({


### PR DESCRIPTION
## 📌 Summary

> - #155 

## 📚 Tasks

- 비로그인 유저 좋아요 제한
- next 파라미터를 활용하여 로그인 후 이전에 있던 페이지로 이동
- 내캡슐 드롭다운 반응형 추가
- 인포 토스트 쪼그라드는 현상 제거


## 👀 To Reviewer
누락된 기능 추가하고 스타일 버그 수정했습니다.

<!--
## 📸 Screenshot

(기재 내용 없을 경우 섹션 삭제) 작업한 내용에 대한 스크린샷을 첨부해주세요. 필요시 .gif 형식으로 첨부해주세요.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신규 기능
  - 로그인 후 쿼리의 next 경로로 동적 리다이렉트 지원 및 OAuth 흐름에서 next 파라미터 유지.
  - 로그인 페이지에 로딩 스피너(Suspense) 적용 및 로고 클릭 시 홈으로 이동.
  - 캡슐 상세의 좋아요 동작에 로그인 필요 보호(미로그인 시 로그인 화면으로 이동).

- 스타일
  - 드롭다운 위치 보정(반응형 기준 조정).
  - 정보 토스트에서 텍스트 줄바꿈 방지로 가독성 개선.

- 작업
  - 사이트 메타데이터 기본 URL 설정.
  - PATH 상수에 LOGIN 경로 추가.
  - 캡슐 상세 푸터 동작 조정(상태별 버튼 표시 변경).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->