### PR TITLE
Feat: 편지 상세 모달 추가

### DIFF
--- a/app/(sub)/capsule-detail/[invite-code]/[id]/letters/_components/grid-letter-card/grid-letter-card.css.ts
+++ b/app/(sub)/capsule-detail/[invite-code]/[id]/letters/_components/grid-letter-card/grid-letter-card.css.ts
@@ -54,4 +54,5 @@ export const content = style({
 
 export const author = style({
   color: themeVars.color.white[40],
+  marginRight: "0.6rem",
 });

--- a/app/(sub)/capsule-detail/[invite-code]/[id]/letters/_components/grid-letter-card/index.tsx
+++ b/app/(sub)/capsule-detail/[invite-code]/[id]/letters/_components/grid-letter-card/index.tsx
@@ -1,18 +1,30 @@
 import type { Letter } from "@/shared/types/api/letter";
 import HoverMotion from "@/shared/ui/motion/hover-motion";
 import Image from "next/image";
+import { overlay } from "overlay-kit";
+import LetterDetailModal from "../letter-detail-modal";
 import * as styles from "./grid-letter-card.css";
 
 interface LetterCardProps {
   letter: Letter;
   imageUrl?: string | null;
-  onClick?: () => void;
 }
 
-const GridLetterCard = ({ letter, imageUrl, onClick }: LetterCardProps) => {
+const GridLetterCard = ({ letter, imageUrl }: LetterCardProps) => {
+  const handleClick = () => {
+    overlay.open(({ isOpen, close }) => (
+      <LetterDetailModal
+        letter={letter}
+        imageUrl={imageUrl}
+        isOpen={isOpen}
+        onClose={close}
+      />
+    ));
+  };
+
   return (
     <HoverMotion>
-      <section className={styles.card} onClick={onClick}>
+      <section className={styles.card} onClick={handleClick} role="button">
         {imageUrl && (
           <Image
             width={200}

--- a/app/(sub)/capsule-detail/[invite-code]/[id]/letters/_components/grid-letter-card/index.tsx
+++ b/app/(sub)/capsule-detail/[invite-code]/[id]/letters/_components/grid-letter-card/index.tsx
@@ -40,7 +40,8 @@ const GridLetterCard = ({ letter, imageUrl }: LetterCardProps) => {
 
         {letter.from && (
           <p>
-            <span className={styles.author}>From</span> {letter.from}
+            <span className={styles.author}>From</span>
+            {letter.from}
           </p>
         )}
       </section>

--- a/app/(sub)/capsule-detail/[invite-code]/[id]/letters/_components/letter-detail-modal/index.tsx
+++ b/app/(sub)/capsule-detail/[invite-code]/[id]/letters/_components/letter-detail-modal/index.tsx
@@ -1,0 +1,50 @@
+import Modal from "@/app/(sub)/capsule-detail/_components/modal";
+import { Letter } from "@/shared/types/api/letter";
+import Image from "next/image";
+import * as styles from "./letter-detail-modal.css";
+
+interface LetterDetailModalProps {
+  letter: Letter;
+  imageUrl?: string | null;
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+const LetterDetailModal = ({
+  letter,
+  imageUrl,
+  isOpen,
+  onClose,
+}: LetterDetailModalProps) => {
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      overlayClassName={styles.modalOverlay}
+      contentClassName={styles.modalContent}
+      fullScreenOnMobile={false}
+    >
+      <section className={styles.container}>
+        {imageUrl && (
+          <Image
+            src={imageUrl}
+            alt="편지 이미지"
+            width={300}
+            height={300}
+            className={styles.image}
+          />
+        )}
+        <div className={styles.contentWrapper}>
+          <p className={styles.content}>{letter.content}</p>
+          {letter.from && (
+            <p className={styles.from}>
+              <span className={styles.author}>From</span> {letter.from}
+            </p>
+          )}
+        </div>
+      </section>
+    </Modal>
+  );
+};
+
+export default LetterDetailModal;

--- a/app/(sub)/capsule-detail/[invite-code]/[id]/letters/_components/letter-detail-modal/index.tsx
+++ b/app/(sub)/capsule-detail/[invite-code]/[id]/letters/_components/letter-detail-modal/index.tsx
@@ -38,7 +38,8 @@ const LetterDetailModal = ({
           <p className={styles.content}>{letter.content}</p>
           {letter.from && (
             <p className={styles.from}>
-              <span className={styles.author}>From</span> {letter.from}
+              <span className={styles.author}>From</span>
+              {letter.from}
             </p>
           )}
         </div>

--- a/app/(sub)/capsule-detail/[invite-code]/[id]/letters/_components/letter-detail-modal/letter-detail-modal.css.ts
+++ b/app/(sub)/capsule-detail/[invite-code]/[id]/letters/_components/letter-detail-modal/letter-detail-modal.css.ts
@@ -1,0 +1,79 @@
+import { themeVars } from "@/shared/styles/base/theme.css";
+import { screen } from "@/shared/styles/tokens/screen";
+import { style } from "@vanilla-extract/css";
+
+export const modalOverlay = style({
+  alignItems: "center",
+});
+
+export const modalContent = style({
+  background: themeVars.color.gradient.darkgray_op,
+  padding: "2rem",
+  ...themeVars.text.B1,
+  color: themeVars.color.white[85],
+  minWidth: "30rem",
+  minHeight: "30rem",
+  position: "relative",
+
+  ...screen.md({
+    padding: "3.2rem",
+    width: "70rem",
+    height: "55rem",
+  }),
+});
+
+export const container = style({
+  display: "flex",
+  flexDirection: "column",
+  gap: "1.6rem",
+  height: "100%",
+  alignItems: "center",
+});
+
+export const contentWrapper = style({
+  display: "flex",
+  flexDirection: "column",
+  alignItems: "flex-start",
+  width: "100%",
+  flex: 1,
+});
+
+export const image = style({
+  flexShrink: 0,
+  width: "100%",
+  height: "auto",
+  objectFit: "cover",
+  borderRadius: "8px",
+  ...screen.md({
+    width: "30rem",
+    height: "30rem",
+  }),
+});
+
+export const content = style({
+  textAlign: "left",
+  flex: 1,
+  display: "-webkit-box",
+  WebkitBoxOrient: "vertical",
+  WebkitLineClamp: 5,
+  overflow: "hidden",
+  textOverflow: "ellipsis",
+  wordBreak: "break-word",
+  paddingBottom: "3.8rem",
+  ...screen.md({
+    WebkitLineClamp: 6,
+    paddingBottom: "4.6rem",
+  }),
+});
+
+export const from = style({
+  position: "absolute",
+  bottom: "2rem",
+  ...screen.md({
+    bottom: "3.2rem",
+  }),
+});
+
+export const author = style({
+  color: themeVars.color.white[40],
+});

--- a/app/(sub)/capsule-detail/[invite-code]/[id]/letters/_components/letter-detail-modal/letter-detail-modal.css.ts
+++ b/app/(sub)/capsule-detail/[invite-code]/[id]/letters/_components/letter-detail-modal/letter-detail-modal.css.ts
@@ -76,4 +76,5 @@ export const from = style({
 
 export const author = style({
   color: themeVars.color.white[40],
+  marginRight: "0.6rem",
 });

--- a/app/(sub)/capsule-detail/[invite-code]/[id]/letters/_components/letter-detail-modal/letter-detail-modal.css.ts
+++ b/app/(sub)/capsule-detail/[invite-code]/[id]/letters/_components/letter-detail-modal/letter-detail-modal.css.ts
@@ -43,7 +43,7 @@ export const image = style({
   width: "100%",
   height: "auto",
   objectFit: "cover",
-  borderRadius: "8px",
+  borderRadius: "14px",
   ...screen.md({
     width: "30rem",
     height: "30rem",

--- a/app/(sub)/capsule-detail/[invite-code]/[id]/letters/_components/stack-letter-card/index.tsx
+++ b/app/(sub)/capsule-detail/[invite-code]/[id]/letters/_components/stack-letter-card/index.tsx
@@ -1,16 +1,28 @@
 import type { Letter } from "@/shared/types/api/letter";
 import Image from "next/image";
+import { overlay } from "overlay-kit";
+import LetterDetailModal from "../letter-detail-modal";
 import * as styles from "./stack-letter-card.css";
 
 interface LetterCardProps {
   letter: Letter;
   imageUrl?: string | null;
-  onClick?: () => void;
 }
 
-const StackLetterCard = ({ letter, imageUrl, onClick }: LetterCardProps) => {
+const StackLetterCard = ({ letter, imageUrl }: LetterCardProps) => {
+  const handleClick = () => {
+    overlay.open(({ isOpen, close }) => (
+      <LetterDetailModal
+        letter={letter}
+        imageUrl={imageUrl}
+        isOpen={isOpen}
+        onClose={close}
+      />
+    ));
+  };
+
   return (
-    <section className={styles.card} onClick={onClick}>
+    <section className={styles.card} onClick={handleClick} role="button">
       <div className={styles.contentWrapper}>
         {imageUrl && (
           <Image

--- a/app/(sub)/capsule-detail/[invite-code]/[id]/letters/_components/stack-letter-card/index.tsx
+++ b/app/(sub)/capsule-detail/[invite-code]/[id]/letters/_components/stack-letter-card/index.tsx
@@ -44,7 +44,8 @@ const StackLetterCard = ({ letter, imageUrl }: LetterCardProps) => {
 
       {letter.from && (
         <p>
-          <span className={styles.author}>From</span> {letter.from}
+          <span className={styles.author}>From</span>
+          {letter.from}
         </p>
       )}
     </section>

--- a/app/(sub)/capsule-detail/[invite-code]/[id]/letters/_components/stack-letter-card/stack-letter-card.css.ts
+++ b/app/(sub)/capsule-detail/[invite-code]/[id]/letters/_components/stack-letter-card/stack-letter-card.css.ts
@@ -14,6 +14,7 @@ export const card = style({
   flexDirection: "column",
   gap: "0.6rem",
   justifyContent: "space-between",
+  cursor: "pointer",
 
   ...screen.md({
     width: "45rem",

--- a/app/(sub)/capsule-detail/[invite-code]/[id]/letters/_components/stack-letter-card/stack-letter-card.css.ts
+++ b/app/(sub)/capsule-detail/[invite-code]/[id]/letters/_components/stack-letter-card/stack-letter-card.css.ts
@@ -53,6 +53,7 @@ export const content = style({
 
 export const author = style({
   color: themeVars.color.white[40],
+  marginRight: "0.6rem",
 });
 
 export const contentWithImage = style({

--- a/app/(sub)/capsule-detail/_components/modal/index.tsx
+++ b/app/(sub)/capsule-detail/_components/modal/index.tsx
@@ -11,6 +11,7 @@ interface ModalProps {
   children: React.ReactNode;
   overlayClassName?: string;
   contentClassName?: string;
+  fullScreenOnMobile?: boolean;
 }
 
 export default function Modal({
@@ -19,6 +20,7 @@ export default function Modal({
   children,
   overlayClassName,
   contentClassName,
+  fullScreenOnMobile = true,
 }: ModalProps) {
   useEffect(() => {
     const handleEscapeKey = (event: KeyboardEvent) => {
@@ -46,6 +48,10 @@ export default function Modal({
     }
   };
 
+  const contentStyles = fullScreenOnMobile
+    ? `${styles.content} ${contentClassName || ""}`
+    : `${styles.contentWithoutFullScreen} ${contentClassName || ""}`;
+
   return createPortal(
     <div
       className={`${styles.overlay} ${overlayClassName || ""}`}
@@ -62,7 +68,7 @@ export default function Modal({
       role="dialog"
       aria-modal="true"
     >
-      <div className={`${styles.content} ${contentClassName || ""}`}>
+      <div className={contentStyles}>
         <div className={styles.body}>{children}</div>
       </div>
     </div>,

--- a/app/(sub)/capsule-detail/_components/modal/modal.css.ts
+++ b/app/(sub)/capsule-detail/_components/modal/modal.css.ts
@@ -1,5 +1,6 @@
 import { themeVars } from "@/shared/styles/base/theme.css";
 import { screen } from "@/shared/styles/tokens/screen";
+import { zIndexTheme } from "@/shared/styles/tokens/z-index";
 import { style } from "@vanilla-extract/css";
 
 export const overlay = style({
@@ -19,6 +20,7 @@ export const overlay = style({
     padding: "20px",
     alignItems: "center",
   }),
+  zIndex: zIndexTheme.modal.content,
 });
 
 export const content = style({
@@ -40,6 +42,20 @@ export const content = style({
     borderRadius: "24px",
     width: "fit-content",
   }),
+});
+
+export const contentWithoutFullScreen = style({
+  backgroundColor: themeVars.color.black["90_bg"],
+  overflow: "hidden",
+  display: "flex",
+  flexDirection: "column",
+  boxShadow:
+    "0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04)",
+
+  maxHeight: "90vh",
+  borderRadius: "24px",
+  width: "fit-content",
+  maxWidth: "90vw",
 });
 
 export const body = style({

--- a/shared/styles/tokens/z-index.ts
+++ b/shared/styles/tokens/z-index.ts
@@ -15,4 +15,7 @@ export const zIndexTheme = {
   dropdown: {
     content: "100",
   },
+  modal: {
+    content: "200",
+  },
 } as const;


### PR DESCRIPTION
## 📌 Summary

> - #137 

## 📚 Tasks

- modal에 `fullScreenOnMobile` prop 추가
- 편지 상세 모달 구현

## 👀 To Reviewer

기존의 modal 컴포넌트를 재사용하고자 prop을 추가해 write-modal에서만 적용되게 하였습니다.

## 📸 Screenshot

<img width="1198" height="963" alt="image" src="https://github.com/user-attachments/assets/40491c6c-6b6b-46c8-aafd-7a80adfe22b2" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 편지 카드를 탭하면 상세 모달이 열려 이미지, 본문, 작성자를 확인할 수 있습니다.
  - 모달이 모바일에서 전체 화면/비전체 화면을 선택적으로 지원합니다.

- Style
  - 작성자 영역 여백을 늘리고 카드에 포인터 커서를 적용해 클릭 가능성을 강화했습니다.
  - “From” 표기와 작성자 표시 레이아웃을 개선했습니다.
  - 모달 시각 스타일과 화면 겹침(z-index)을 조정해 가독성과 안정성을 높였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->