### PR TITLE
Feat: 캡슐 떠나기 기능 추가

### DIFF
--- a/app/(main)/explore/page.tsx
+++ b/app/(main)/explore/page.tsx
@@ -29,7 +29,7 @@ const Explore = () => {
 
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isPending } =
     useInfiniteQuery(
-      capsuleQueryOptions.infiniteCapsuleLists(selectedSort, selectedTab),
+      capsuleQueryOptions.capsuleLists(selectedSort, selectedTab),
     );
 
   const handleSelect = (value: string) => {

--- a/app/(main)/my-capsule/page.tsx
+++ b/app/(main)/my-capsule/page.tsx
@@ -27,7 +27,7 @@ const MyCapsule = () => {
 
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isPending } =
     useInfiniteQuery(
-      capsuleQueryOptions.infiniteMyCapsuleList(selectedSort, selectedTab),
+      capsuleQueryOptions.myCapsuleList(selectedSort, selectedTab),
     );
 
   const onIntersect = useCallback(

--- a/app/(sub)/capsule-detail/[invite-code]/[id]/page.css.ts
+++ b/app/(sub)/capsule-detail/[invite-code]/[id]/page.css.ts
@@ -1,8 +1,13 @@
 import { style } from "@vanilla-extract/css";
+import { themeVars } from "@/shared/styles/base/theme.css";
 
 export const container = style({
   display: "flex",
   flexDirection: "column",
   gap: "1.6rem",
   margin: "0 1.6rem",
+});
+
+export const textHighlight = style({
+  color: themeVars.color.semantic.red,
 });

--- a/app/(sub)/capsule-detail/[invite-code]/[id]/page.tsx
+++ b/app/(sub)/capsule-detail/[invite-code]/[id]/page.tsx
@@ -14,7 +14,6 @@ import PopupReport from "@/shared/ui/popup/popup-report";
 import PopupWarningCapsule from "@/shared/ui/popup/popup-warning-capsule";
 import { formatDateTime } from "@/shared/utils/date";
 import { useQuery } from "@tanstack/react-query";
-import Link from "next/link";
 import {
   useParams,
   usePathname,
@@ -27,6 +26,7 @@ import CaptionSection from "../../_components/caption-section";
 import InfoTitle from "../../_components/info-title";
 import OpenInfoSection from "../../_components/open-info-section";
 import ResponsiveFooter from "../../_components/responsive-footer";
+import { useLeaveCapsule } from "@/shared/api/mutations/capsule";
 import * as styles from "./page.css";
 
 const CapsuleDetailPage = () => {
@@ -37,6 +37,7 @@ const CapsuleDetailPage = () => {
     capsuleQueryOptions.capsuleDetail(id),
   );
   const { data: user } = useQuery(userQueryOptions.userInfo());
+  const { mutate: leaveCapsule } = useLeaveCapsule();
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
@@ -65,6 +66,15 @@ const CapsuleDetailPage = () => {
     likeToggle({ id: result.id.toString(), isLiked: nextLiked });
   };
 
+  const handleLeaveCapsule = (close: () => void) => {
+    close();
+    leaveCapsule(result.id.toString(), {
+      onSuccess: () => {
+        router.push(PATH.EXPLORE);
+      },
+    });
+  };
+
   return (
     <>
       <NavbarDetail
@@ -88,11 +98,18 @@ const CapsuleDetailPage = () => {
                       ));
                     }}
                   />
-                    <Dropdown.Item label="캡슐 떠나기" className={styles.textHighlight} onClick={() => {
+                  <Dropdown.Item
+                    label="캡슐 떠나기"
+                    className={styles.textHighlight}
+                    onClick={() => {
                       overlay.open(({ isOpen, close }) => (
-                        <PopupWarningCapsule isOpen={isOpen} close={close} />
+                        <PopupWarningCapsule
+                          isOpen={isOpen}
+                          onConfirm={() => handleLeaveCapsule(close)}
+                        />
                       ));
-                    }}/>
+                    }}
+                  />
                 </Dropdown.Content>
               </Dropdown>
             </>

--- a/app/(sub)/capsule-detail/[invite-code]/[id]/page.tsx
+++ b/app/(sub)/capsule-detail/[invite-code]/[id]/page.tsx
@@ -128,7 +128,7 @@ const CapsuleDetailPage = () => {
       <CapsuleImage imageUrl={result.beadVideoUrl} />
       <div className={styles.container}>
         <RevealMotion delay={0.8}>
-          <CaptionSection description={result.subtitle} />
+          {result.subtitle && <CaptionSection description={result.subtitle} />}
         </RevealMotion>
         <RevealMotion delay={1.2}>
           <OpenInfoSection openAt={formatDateTime(result.openAt)} />

--- a/app/(sub)/capsule-detail/[invite-code]/[id]/page.tsx
+++ b/app/(sub)/capsule-detail/[invite-code]/[id]/page.tsx
@@ -11,6 +11,7 @@ import LoadingSpinner from "@/shared/ui/loading-spinner";
 import RevealMotion from "@/shared/ui/motion/reveal-motion";
 import NavbarDetail from "@/shared/ui/navbar/navbar-detail";
 import PopupReport from "@/shared/ui/popup/popup-report";
+import PopupWarningCapsule from "@/shared/ui/popup/popup-warning-capsule";
 import { formatDateTime } from "@/shared/utils/date";
 import { useQuery } from "@tanstack/react-query";
 import Link from "next/link";
@@ -87,9 +88,11 @@ const CapsuleDetailPage = () => {
                       ));
                     }}
                   />
-                  <Link href={PATH.HOME}>
-                    <Dropdown.Item label="나가기" />
-                  </Link>
+                    <Dropdown.Item label="캡슐 떠나기" className={styles.textHighlight} onClick={() => {
+                      overlay.open(({ isOpen, close }) => (
+                        <PopupWarningCapsule isOpen={isOpen} close={close} />
+                      ));
+                    }}/>
                 </Dropdown.Content>
               </Dropdown>
             </>

--- a/app/(sub)/capsule-detail/[invite-code]/[id]/page.tsx
+++ b/app/(sub)/capsule-detail/[invite-code]/[id]/page.tsx
@@ -98,9 +98,10 @@ const CapsuleDetailPage = () => {
                       ));
                     }}
                   />
-                  <Dropdown.Item
-                    label="캡슐 떠나기"
-                    className={styles.textHighlight}
+                  {result.isJoined && (
+                    <Dropdown.Item
+                      label="캡슐 떠나기"
+                      className={styles.textHighlight}
                     onClick={() => {
                       overlay.open(({ isOpen, close }) => (
                         <PopupWarningCapsule
@@ -108,8 +109,9 @@ const CapsuleDetailPage = () => {
                           onConfirm={() => handleLeaveCapsule(close)}
                         />
                       ));
-                    }}
-                  />
+                      }}
+                    />
+                  )}
                 </Dropdown.Content>
               </Dropdown>
             </>

--- a/shared/api/mutations/capsule.ts
+++ b/shared/api/mutations/capsule.ts
@@ -36,3 +36,22 @@ export const useLikeToggle = () => {
     },
   });
 };
+
+export const useLeaveCapsule = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (id: string) => {
+      await apiClient.delete(ENDPOINTS.LEAVE_CAPSULE(id));
+      return id;
+    },
+    onSuccess: (id: string) => {
+      queryClient.invalidateQueries({
+        queryKey: [
+          capsuleQueryKeys.detail(id),
+          capsuleQueryKeys.lists(),
+          capsuleQueryKeys.my(),
+        ],
+      });
+    },
+  });
+};

--- a/shared/api/queries/capsule.ts
+++ b/shared/api/queries/capsule.ts
@@ -14,27 +14,15 @@ import { apiClient } from "../api-client";
 export const capsuleQueryKeys = {
   all: () => ["capsule"],
   detail: (id: string) => [...capsuleQueryKeys.all(), id],
-  lists: (
-    page?: number,
-    size?: number,
-    sort?: CapsuleSortType,
-    type?: string,
-  ) => [...capsuleQueryKeys.all(), "lists", page, size, sort, type],
-  infiniteLists: (sort?: CapsuleSortType, type?: string) => [
+  lists: (sort?: CapsuleSortType, type?: string) => [
     ...capsuleQueryKeys.all(),
-    "infiniteLists",
+    "lists",
     sort,
     type,
   ],
-  my: (
-    page?: number,
-    size?: number,
-    sort?: CapsuleSortType,
-    filter?: MyCapsuleFilterType,
-  ) => [...capsuleQueryKeys.all(), "my", page, size, sort, filter],
-  infiniteMy: (sort?: CapsuleSortType, filter?: MyCapsuleFilterType) => [
+  my: (sort?: CapsuleSortType, filter?: MyCapsuleFilterType) => [
     ...capsuleQueryKeys.all(),
-    "infiniteMy",
+    "my",
     sort,
     filter,
   ],
@@ -47,19 +35,10 @@ export const capsuleQueryOptions = {
       queryFn: () => getCapsuleDetail(id),
       enabled: !!id,
     }),
-  capsuleLists: (
-    page?: number,
-    size?: number,
-    sort?: CapsuleSortType,
-    type?: string,
-  ) =>
-    queryOptions({
-      queryKey: capsuleQueryKeys.lists(page, size, sort, type),
-      queryFn: () => getCapsuleLists(page, size, sort, type),
-    }),
-  infiniteCapsuleLists: (sort?: CapsuleSortType, type?: string) =>
+
+  capsuleLists: (sort?: CapsuleSortType, type?: string) =>
     infiniteQueryOptions({
-      queryKey: capsuleQueryKeys.infiniteLists(sort, type),
+      queryKey: capsuleQueryKeys.lists(sort, type),
       queryFn: ({ pageParam = 0 }) =>
         getCapsuleLists(pageParam, 20, sort, type),
       getNextPageParam: (lastPage) => {
@@ -68,22 +47,10 @@ export const capsuleQueryOptions = {
       },
       initialPageParam: 0,
     }),
-  myCapsuleList: (
-    page?: number,
-    size?: number,
-    sort?: CapsuleSortType,
-    filter?: MyCapsuleFilterType,
-  ) =>
-    queryOptions({
-      queryKey: capsuleQueryKeys.my(page, size, sort, filter),
-      queryFn: () => getMyCapsuleList(page, size, sort, filter),
-    }),
-  infiniteMyCapsuleList: (
-    sort?: CapsuleSortType,
-    filter?: MyCapsuleFilterType,
-  ) =>
+
+  myCapsuleList: (sort?: CapsuleSortType, filter?: MyCapsuleFilterType) =>
     infiniteQueryOptions({
-      queryKey: capsuleQueryKeys.infiniteMy(sort, filter),
+      queryKey: capsuleQueryKeys.my(sort, filter),
       queryFn: ({ pageParam = 0 }) =>
         getMyCapsuleList(pageParam, 20, sort, filter),
       getNextPageParam: (lastPage) => {
@@ -102,10 +69,10 @@ const getCapsuleLists = (
   page?: number,
   size?: number,
   sort?: CapsuleSortType,
-  type?: string,
+  type?: string
 ) => {
   return apiClient.get<CapsuleListsRes>(
-    ENDPOINTS.CAPSULE_LISTS(page, size, sort, type),
+    ENDPOINTS.CAPSULE_LISTS(page, size, sort, type)
   );
 };
 
@@ -113,9 +80,9 @@ const getMyCapsuleList = (
   page?: number,
   size?: number,
   sort?: CapsuleSortType,
-  filter?: MyCapsuleFilterType,
+  filter?: MyCapsuleFilterType
 ) => {
   return apiClient.get<CapsuleListsRes>(
-    ENDPOINTS.MY_CAPSULE_LIST(page, size, sort, filter),
+    ENDPOINTS.MY_CAPSULE_LIST(page, size, sort, filter)
   );
 };

--- a/shared/constants/endpoints.ts
+++ b/shared/constants/endpoints.ts
@@ -8,11 +8,13 @@ export const ENDPOINTS = {
     page = 0,
     size = 20,
     sort: CapsuleSortType = "DEFAULT",
-    type = "all",
+    type = "all"
   ) =>
     `api/v1/capsules/explore?page=${page}&size=${size}&sort=${sort}${
       type === "all" ? "" : `&type=${type}`
     }`,
+
+  LEAVE_CAPSULE: (id: string) => `api/v1/capsules/${id}/leave`,
 
   LIKE_TOGGLE: (id: string) => `api/v1/capsules/${id}/like`,
 
@@ -20,7 +22,7 @@ export const ENDPOINTS = {
     page = 0,
     size = 20,
     sort: CapsuleSortType = "DEFAULT",
-    filter = "ALL",
+    filter = "ALL"
   ) =>
     `api/v1/capsules/my?page=${page}&size=${size}&sort=${sort}&filter=${filter}`,
 

--- a/shared/hooks/use-funnel.tsx
+++ b/shared/hooks/use-funnel.tsx
@@ -1,6 +1,5 @@
-import { useRouter, useSearchParams } from "next/navigation";
 import type { ReactElement, ReactNode } from "react";
-import { useEffect } from "react";
+import { useState } from "react";
 
 interface StepProps {
   name: string;
@@ -12,25 +11,7 @@ interface FunnelProps {
 }
 
 export const useFunnel = () => {
-  const router = useRouter();
-  const searchParams = useSearchParams();
-
-  const step = searchParams.get("step") || "intro";
-
-  useEffect(() => {
-    const currentStep = searchParams.get("step");
-    if (!currentStep) {
-      const params = new URLSearchParams(searchParams);
-      params.set("step", "intro");
-      router.replace(`?${params.toString()}`);
-    }
-  }, []);
-
-  const setStep = (step: string) => {
-    const params = new URLSearchParams(searchParams);
-    params.set("step", step);
-    router.replace(`?${params.toString()}`);
-  };
+  const [step, setStep] = useState("intro");
 
   const Step = ({ children }: StepProps) => {
     return <>{children}</>;

--- a/shared/types/api/capsule.ts
+++ b/shared/types/api/capsule.ts
@@ -26,6 +26,7 @@ export interface CapsuleDetailRes {
     letterCount: number;
     likeCount: number;
     isLiked: boolean;
+    isJoined: boolean;
     status: CapsuleStatus;
     remainingTime: {
       days: number;

--- a/shared/ui/navbar/navbar-detail/index.tsx
+++ b/shared/ui/navbar/navbar-detail/index.tsx
@@ -4,6 +4,7 @@ import BackIcon from "@/shared/assets/icon/left.svg";
 import { cn } from "@/shared/utils/cn";
 import { useRouter } from "next/navigation";
 import type { ReactElement } from "react";
+import { PATH } from "@/shared/constants/path";
 import * as styles from "./navbar-detail.css";
 
 interface NavbarDetailProps {
@@ -15,11 +16,19 @@ const NavbarDetail = ({ renderRight, className }: NavbarDetailProps) => {
   const router = useRouter();
   const renderRightElement = renderRight ? renderRight() : null;
 
+  const handleBack = () => {
+    if (window.history.length <= 1) {
+      router.push(PATH.EXPLORE);
+    } else {
+      router.back();
+    }
+  };
+
   return (
     <div className={styles.container}>
       <button
         type="button"
-        onClick={() => router.back()}
+        onClick={handleBack}
         className={styles.backButton}
       >
         <BackIcon />

--- a/shared/ui/popup/index.tsx
+++ b/shared/ui/popup/index.tsx
@@ -1,5 +1,5 @@
-import { useEffect } from "react";
-
+import { useEffect, useState } from "react";
+import { useOutsideClickEffect } from "react-simplikit";
 import { themeClass } from "@/shared/styles/base/theme.css";
 import { cn } from "@/shared/utils/cn";
 import type { ComponentProps, ReactNode } from "react";
@@ -41,6 +41,7 @@ interface PopupRootProps extends PopupProps {
 }
 
 const PopupRoot = ({ children, className, open, close }: PopupRootProps) => {
+  const [wrapperEl, setWrapperEl] = useState<HTMLDivElement | null>(null);
   useEffect(() => {
     const handleEscKey = (event: KeyboardEvent) => {
       if (event.key === "Escape" && close) {
@@ -54,15 +55,20 @@ const PopupRoot = ({ children, className, open, close }: PopupRootProps) => {
     }
   }, [open, close]);
 
+  useOutsideClickEffect(wrapperEl, () => {
+    close();
+  });
+
   if (typeof window === "undefined" || !open) return null;
 
   return createPortal(
-    <div className={themeClass}>
+    <div className={themeClass} >
       <div className={styles.dim}>
         <div
           className={cn(styles.root, className)}
           role="dialog"
           aria-modal="true"
+          ref={setWrapperEl}
         >
           {children}
         </div>

--- a/shared/ui/popup/popup-warning-capsule/index.tsx
+++ b/shared/ui/popup/popup-warning-capsule/index.tsx
@@ -4,10 +4,13 @@ import * as styles from "./popup-warning-capsule.css";
 
 interface PopupWarningCapsuleProps {
   isOpen: boolean;
-  close: () => void;
+  onConfirm: () => void;
 }
 
-const PopupWarningCapsule = ({ isOpen, close }: PopupWarningCapsuleProps) => {
+const PopupWarningCapsule = ({
+  isOpen,
+  onConfirm,
+}: PopupWarningCapsuleProps) => {
   return (
     <Popup open={isOpen} close={close}>
       <div className={styles.iconWrapper}>
@@ -21,7 +24,7 @@ const PopupWarningCapsule = ({ isOpen, close }: PopupWarningCapsuleProps) => {
       </Popup.Content>
       <Popup.Actions>
         <Popup.Button onClick={close}>돌아가기</Popup.Button>
-        <Popup.Button className={styles.continueButton} onClick={close}>
+        <Popup.Button className={styles.continueButton} onClick={onConfirm}>
           떠나기
         </Popup.Button>
       </Popup.Actions>

--- a/shared/ui/popup/popup-warning-capsule/index.tsx
+++ b/shared/ui/popup/popup-warning-capsule/index.tsx
@@ -15,13 +15,14 @@ const PopupWarningCapsule = ({ isOpen, close }: PopupWarningCapsuleProps) => {
       </div>
       <Popup.Title>정말 캡슐을 떠나시겠어요?</Popup.Title>
       <Popup.Content>
-        <p>나가면 다시 캡슐에 참여할 수 없으며,</p>
-        <p>담은 편지가 사라지지 않아요.</p>
+        <p>떠나면 이 캡슐은 본인에게 보이지 않으며,</p>
+        <p>다시 참여할 수도 없습니다.</p>
+        <p>작성한 편지도 확인할 수 없습니다.</p>
       </Popup.Content>
       <Popup.Actions>
         <Popup.Button onClick={close}>돌아가기</Popup.Button>
         <Popup.Button className={styles.continueButton} onClick={close}>
-          계속 쓰기
+          떠나기
         </Popup.Button>
       </Popup.Actions>
     </Popup>

--- a/shared/ui/popup/popup-warning-capsule/popup-warning-capsule.css.ts
+++ b/shared/ui/popup/popup-warning-capsule/popup-warning-capsule.css.ts
@@ -6,5 +6,5 @@ export const iconWrapper = style({
 });
 
 export const continueButton = style({
-  color: themeVars.color.purple[10],
+  color: themeVars.color.semantic.red,
 });


### PR DESCRIPTION
## 📌 Summary

> - #180 

## 📚 Tasks

- 상세 조회 isJoined 필드 추가 반영
- isJoined 값에 따라 드롭다운에 캡슐 떠나기 옵션 추가되도록 수정
- 캡슐 떠나기 확인 팝업 추가
- 캡슐 떠나기 api 연결
- 링크 공유를 통해 헤더의 back버튼 누를 경우 /explore로 이동
- 불필요한 쿼리키, 쿼리 옵션 제거

## To Reviewer
캡슐 떠나기 api 호출 성공 후에도 내캡슐 목록에 해당 캡슐이 남아있는 오류가 있어, 서버에 수정 요청해놨습니다!

## 📸 Screenshot
### 캡슐 떠나기 성공 후 explore로 이동

https://github.com/user-attachments/assets/6e33c2f4-eed4-454c-ab78-10b1efb0f327


### isJoined 값에 따라 드롭다운에 캡슐 떠나기 옵션 추가되도록 수정
#### 참여한 캡슐일 때

<img width="890" height="228" alt="스크린샷 2025-08-20 오전 12 04 08" src="https://github.com/user-attachments/assets/859c94bc-bc61-4528-81d7-dc75e2c902c1" />

#### 참여하지 않은 캡슐일 때
<img width="890" height="215" alt="스크린샷 2025-08-20 오전 12 03 58" src="https://github.com/user-attachments/assets/989db1f9-204d-45d0-8715-01bfee9084d5" />

