### PR TITLE
Qa: 편지쓰기 모달 QA 반영

### DIFF
--- a/app/(main)/setting/page.tsx
+++ b/app/(main)/setting/page.tsx
@@ -9,8 +9,7 @@ import { useRouter } from "next/navigation";
 import SettingItem from "./_components/setting-item";
 import SettingSection from "./_components/setting-section";
 import UserGreetingSection from "./_components/user-greeting-section";
-
-import { overlay } from "overlay-kit";
+import { useOverlay } from "@/shared/hooks/use-overlay";
 import * as styles from "./page.css";
 
 const Setting = () => {
@@ -18,6 +17,7 @@ const Setting = () => {
   const router = useRouter();
   const queryClient = useQueryClient();
   const { data: userInfo } = useQuery(userQueryOptions.userInfo({}));
+  const { open } = useOverlay();
 
   const handleLogout = () => {
     logout(undefined, {
@@ -38,7 +38,7 @@ const Setting = () => {
         </SettingSection>
         <SettingSection category="고객센터">
           <SettingItem onClick={() =>
-              overlay.open(({ isOpen, close }) => (
+              open(({ isOpen, close }) => (
                 <PopupReport
                   isOpen={isOpen}
                   close={close}
@@ -47,7 +47,7 @@ const Setting = () => {
             }>문의하기</SettingItem>
           <SettingItem
             onClick={() =>
-              overlay.open(({ isOpen, close }) => (
+              open(({ isOpen, close }) => (
                 <PopupLogout
                   isOpen={isOpen}
                   close={close}

--- a/app/(sub)/capsule-detail/[invite-code]/[id]/letters/_components/grid-letter-card/index.tsx
+++ b/app/(sub)/capsule-detail/[invite-code]/[id]/letters/_components/grid-letter-card/index.tsx
@@ -1,7 +1,7 @@
 import type { Letter } from "@/shared/types/api/letter";
 import HoverMotion from "@/shared/ui/motion/hover-motion";
 import Image from "next/image";
-import { overlay } from "overlay-kit";
+import { useOverlay } from "@/shared/hooks/use-overlay";
 import LetterDetailModal from "../letter-detail-modal";
 import * as styles from "./grid-letter-card.css";
 
@@ -11,8 +11,10 @@ interface LetterCardProps {
 }
 
 const GridLetterCard = ({ letter, imageUrl }: LetterCardProps) => {
+  const { open } = useOverlay();
+
   const handleClick = () => {
-    overlay.open(({ isOpen, close }) => (
+    open(({ isOpen, close }) => (
       <LetterDetailModal
         letter={letter}
         imageUrl={imageUrl}

--- a/app/(sub)/capsule-detail/[invite-code]/[id]/letters/_components/stack-letter-card/index.tsx
+++ b/app/(sub)/capsule-detail/[invite-code]/[id]/letters/_components/stack-letter-card/index.tsx
@@ -1,6 +1,6 @@
 import type { Letter } from "@/shared/types/api/letter";
 import Image from "next/image";
-import { overlay } from "overlay-kit";
+import { useOverlay } from "@/shared/hooks/use-overlay";
 import LetterDetailModal from "../letter-detail-modal";
 import * as styles from "./stack-letter-card.css";
 
@@ -10,8 +10,10 @@ interface LetterCardProps {
 }
 
 const StackLetterCard = ({ letter, imageUrl }: LetterCardProps) => {
+  const { open } = useOverlay();
+
   const handleClick = () => {
-    overlay.open(({ isOpen, close }) => (
+    open(({ isOpen, close }) => (
       <LetterDetailModal
         letter={letter}
         imageUrl={imageUrl}

--- a/app/(sub)/capsule-detail/[invite-code]/[id]/page.tsx
+++ b/app/(sub)/capsule-detail/[invite-code]/[id]/page.tsx
@@ -28,6 +28,7 @@ import OpenInfoSection from "../../_components/open-info-section";
 import ResponsiveFooter from "../../_components/responsive-footer";
 import { useLeaveCapsule } from "@/shared/api/mutations/capsule";
 import * as styles from "./page.css";
+import { oauthUtils } from "@/shared/utils/oauth";
 
 const CapsuleDetailPage = () => {
   const params = useParams();
@@ -56,11 +57,9 @@ const CapsuleDetailPage = () => {
 
   const handleLikeToggle = (nextLiked: boolean) => {
     if (!isLoggedIn) {
-      const current = `${pathname}${
-        searchParams?.toString() ? `?${searchParams.toString()}` : ""
-      }`;
-      const loginUrl = `${PATH.LOGIN}?next=${encodeURIComponent(current)}`;
-      router.push(loginUrl);
+      const current = oauthUtils.buildCurrentUrl(pathname, searchParams);
+      oauthUtils.saveNextUrl(current);
+      router.push(PATH.LOGIN);
       return;
     }
     likeToggle({ id: result.id.toString(), isLiked: nextLiked });

--- a/app/(sub)/capsule-detail/[invite-code]/[id]/page.tsx
+++ b/app/(sub)/capsule-detail/[invite-code]/[id]/page.tsx
@@ -20,7 +20,6 @@ import {
   useRouter,
   useSearchParams,
 } from "next/navigation";
-import { overlay } from "overlay-kit";
 import CapsuleImage from "../../_components/capsule-image";
 import CaptionSection from "../../_components/caption-section";
 import InfoTitle from "../../_components/info-title";
@@ -29,6 +28,7 @@ import ResponsiveFooter from "../../_components/responsive-footer";
 import { useLeaveCapsule } from "@/shared/api/mutations/capsule";
 import * as styles from "./page.css";
 import { oauthUtils } from "@/shared/utils/oauth";
+import { useOverlay } from "@/shared/hooks/use-overlay";
 
 const CapsuleDetailPage = () => {
   const params = useParams();
@@ -42,6 +42,7 @@ const CapsuleDetailPage = () => {
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
+  const { open } = useOverlay();
 
   const isLoggedIn = !!user?.result;
 
@@ -92,7 +93,7 @@ const CapsuleDetailPage = () => {
                   <Dropdown.Item
                     label="신고하기"
                     onClick={() => {
-                      overlay.open(({ isOpen, close }) => (
+                      open(({ isOpen, close }) => (
                         <PopupReport isOpen={isOpen} close={close} />
                       ));
                     }}
@@ -102,7 +103,7 @@ const CapsuleDetailPage = () => {
                       label="캡슐 떠나기"
                       className={styles.textHighlight}
                     onClick={() => {
-                      overlay.open(({ isOpen, close }) => (
+                      open(({ isOpen, close }) => (
                         <PopupWarningCapsule
                           isOpen={isOpen}
                           close={close}

--- a/app/(sub)/capsule-detail/_components/responsive-footer/index.tsx
+++ b/app/(sub)/capsule-detail/_components/responsive-footer/index.tsx
@@ -16,6 +16,7 @@ import { PATH } from "@/shared/constants/path";
 import type { CapsuleDetailRes } from "@/shared/types/api/capsule";
 import { formatOpenDate } from "@/shared/utils/date";
 import * as styles from "./responsive-footer.css";
+import { oauthUtils } from "@/shared/utils/oauth";
 
 interface ResponsiveFooterProps {
   capsuleData: CapsuleDetailRes;
@@ -55,11 +56,9 @@ const ResponsiveFooter = ({
 
   const handleWriteButtonClick = () => {
     if (!isLoggedIn) {
-      const current = `${pathname}${
-        searchParams?.toString() ? `?${searchParams.toString()}` : ""
-      }`;
-      const loginUrl = `${PATH.LOGIN}?next=${encodeURIComponent(current)}`;
-      router.push(loginUrl);
+      const current = oauthUtils.buildCurrentUrl(pathname, searchParams);
+      oauthUtils.saveNextUrl(current);
+      router.push(PATH.LOGIN);
       return;
     }
 

--- a/app/(sub)/capsule-detail/_components/responsive-footer/index.tsx
+++ b/app/(sub)/capsule-detail/_components/responsive-footer/index.tsx
@@ -7,7 +7,6 @@ import InfoToast from "@/shared/ui/info-toast";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useState } from "react";
 import { useTimeout } from "react-simplikit";
-
 import WriteModal from "../write-modal";
 
 import ShakeYMotion from "@/shared/ui/motion/shakeY-motion";
@@ -17,6 +16,7 @@ import type { CapsuleDetailRes } from "@/shared/types/api/capsule";
 import { formatOpenDate } from "@/shared/utils/date";
 import * as styles from "./responsive-footer.css";
 import { oauthUtils } from "@/shared/utils/oauth";
+import { useOverlay } from "@/shared/hooks/use-overlay";
 
 interface ResponsiveFooterProps {
   capsuleData: CapsuleDetailRes;
@@ -31,9 +31,9 @@ const ResponsiveFooter = ({
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const [isCopied, setIsCopied] = useState(false);
-  const [isWriteModalOpen, setIsWriteModalOpen] = useState(false);
   const [showSuccessToast, setShowSuccessToast] = useState(false);
   const { status, remainingTime } = capsuleData.result;
+  const { open } = useOverlay();
 
   useTimeout(
     () => {
@@ -62,7 +62,14 @@ const ResponsiveFooter = ({
       return;
     }
 
-    setIsWriteModalOpen(true);
+    open(({ isOpen, close }) => (
+      <WriteModal
+        capsuleData={capsuleData}
+        isOpen={isOpen}
+        onClose={close}
+        onSuccess={() => setShowSuccessToast(true)}
+      />
+    ));
   };
 
   const handleOpenCapsuleClick = () => {
@@ -170,15 +177,6 @@ const ResponsiveFooter = ({
     <div className={styles.container}>
       <div className={styles.buttonContainer}>{renderButtons()}</div>
       {renderTimeInfo()}
-
-      {isWriteModalOpen && (
-        <WriteModal
-          capsuleData={capsuleData}
-          isOpen={isWriteModalOpen}
-          onClose={() => setIsWriteModalOpen(false)}
-          onSuccess={() => setShowSuccessToast(true)}
-        />
-      )}
       {showSuccessToast && <InfoToast status="WRITABLE" />}
     </div>
   );

--- a/app/(sub)/capsule-detail/_components/write-modal/_hooks/use-image-upload.ts
+++ b/app/(sub)/capsule-detail/_components/write-modal/_hooks/use-image-upload.ts
@@ -1,5 +1,5 @@
 import { useFileUpload } from "@/shared/api/mutations/file";
-import { useEffect, useState } from "react";
+import { useEffect, useState, useCallback } from "react";
 
 interface useImageUploadProps {
   onObjectKeyChange: (value: string) => void;
@@ -57,13 +57,13 @@ export const useImageUpload = ({ onObjectKeyChange }: useImageUploadProps) => {
     });
   };
 
-  const removeImage = () => {
+  const removeImage = useCallback(() => {
     if (uploadedImageUrl) {
       URL.revokeObjectURL(uploadedImageUrl);
     }
     setUploadedImageUrl(null);
     onObjectKeyChange("");
-  };
+  }, [uploadedImageUrl, onObjectKeyChange]);
 
   return {
     uploadedImageUrl,

--- a/app/(sub)/capsule-detail/_components/write-modal/index.tsx
+++ b/app/(sub)/capsule-detail/_components/write-modal/index.tsx
@@ -15,7 +15,7 @@ import type { WriteLetterReq } from "@/shared/types/api/letter";
 import { formatOpenDateString } from "@/shared/utils/date";
 import Image from "next/image";
 import { useState } from "react";
-import { useForm } from "react-hook-form";
+import { useForm, useController } from "react-hook-form";
 import Modal from "../modal";
 import { useImageUpload } from "./_hooks/use-image-upload";
 import * as styles from "./write-modal.css";
@@ -42,6 +42,7 @@ const WriteModal = ({
     handleSubmit,
     setValue,
     getValues,
+    control,
     formState: { errors },
   } = useForm<WriteLetterReq>({
     defaultValues: {
@@ -50,6 +51,16 @@ const WriteModal = ({
       from: "",
       objectKeys: "",
     },
+  });
+
+  const { field: contentField } = useController({
+    name: "content",
+    control,
+  });
+
+  const { field: fromField } = useController({
+    name: "from",
+    control,
   });
 
   const { uploadedImageUrl, handleImageUpload, removeImage, isUploading } =
@@ -125,10 +136,12 @@ const WriteModal = ({
                 <textarea
                   className={styles.textarea}
                   placeholder="나누고 싶은 생각을 공유해보세요!"
-                {...register("content", {
-                  required: "편지 내용을 입력해주세요.",
-                })}
-              />
+                  {...contentField}
+                  maxLength={1000}
+                />
+                <span className={styles.charCount}>
+                  {contentField.value?.length || 0}/1000
+                </span>
               </div>
               
               {uploadedImageUrl ? (
@@ -155,13 +168,13 @@ const WriteModal = ({
                     className={styles.imageAddButton}
                     onClick={handleImageUpload}
                     disabled={isUploading}
-                  aria-label="이미지 추가"
-                >
-                  <div className={styles.plusIconWrapper}>
-                    <Plus className={styles.plusIcon} />
-                  </div>
-                  <span className={styles.imageCaption}>
-                    {isUploading ? "업로드 중..." : "이미지 추가"}
+                    aria-label="이미지 추가"
+                  >
+                    <div className={styles.plusIconWrapper}>
+                      <Plus className={styles.plusIcon} />
+                    </div>
+                    <span className={styles.imageCaption}>
+                      {isUploading ? "업로드 중..." : "이미지 추가"}
                     </span>
                   </button>
                 </div>
@@ -172,13 +185,19 @@ const WriteModal = ({
           <RevealMotion delay={0.9}>
             <div className={styles.inputSection}>
               <p className={styles.senderTitle}>보내는 사람</p>
-              <input
-                id="sender-name"
-                type="text"
-                placeholder="꼭 입력하지 않아도 괜찮아요"
-                className={styles.senderInput}
-                {...register("from")}
-              />
+              <div className={styles.senderInputContainer}>
+                <input
+                  id="sender-name"
+                  type="text"
+                  placeholder="꼭 입력하지 않아도 괜찮아요"
+                  className={styles.senderInput}
+                  {...fromField}
+                  maxLength={20}
+                />
+                <span className={styles.senderCharCount}>
+                  {fromField.value?.length || 0}/20
+                </span>
+              </div>
             </div>
           </RevealMotion>
         </div>

--- a/app/(sub)/capsule-detail/_components/write-modal/index.tsx
+++ b/app/(sub)/capsule-detail/_components/write-modal/index.tsx
@@ -121,20 +121,16 @@ const WriteModal = ({
 
           <RevealMotion delay={0.6}>
             <div className={styles.textareaContainer}>
-              <textarea
-                className={styles.textarea}
-                placeholder="나누고 싶은 생각을 공유해보세요!"
+              <div className={styles.textareaDiv}>
+                <textarea
+                  className={styles.textarea}
+                  placeholder="나누고 싶은 생각을 공유해보세요!"
                 {...register("content", {
                   required: "편지 내용을 입력해주세요.",
                 })}
               />
-
-              {errors.content && (
-                <div className={styles.errorMessage}>
-                  {errors.content.message}
-                </div>
-              )}
-
+              </div>
+              
               {uploadedImageUrl ? (
                 <div className={styles.imagePreviewContainer}>
                   <button
@@ -153,11 +149,12 @@ const WriteModal = ({
                   />
                 </div>
               ) : (
-                <button
-                  type="button"
-                  className={styles.imageAddButton}
-                  onClick={handleImageUpload}
-                  disabled={isUploading}
+                <div className={styles.imageAddButtonContainer}>
+                  <button
+                    type="button"
+                    className={styles.imageAddButton}
+                    onClick={handleImageUpload}
+                    disabled={isUploading}
                   aria-label="이미지 추가"
                 >
                   <div className={styles.plusIconWrapper}>
@@ -165,8 +162,9 @@ const WriteModal = ({
                   </div>
                   <span className={styles.imageCaption}>
                     {isUploading ? "업로드 중..." : "이미지 추가"}
-                  </span>
-                </button>
+                    </span>
+                  </button>
+                </div>
               )}
             </div>
           </RevealMotion>

--- a/app/(sub)/capsule-detail/_components/write-modal/index.tsx
+++ b/app/(sub)/capsule-detail/_components/write-modal/index.tsx
@@ -14,7 +14,7 @@ import type { CapsuleDetailRes } from "@/shared/types/api/capsule";
 import type { WriteLetterReq } from "@/shared/types/api/letter";
 import { formatOpenDateString } from "@/shared/utils/date";
 import Image from "next/image";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useForm, useController } from "react-hook-form";
 import Modal from "../modal";
 import { useImageUpload } from "./_hooks/use-image-upload";
@@ -43,6 +43,7 @@ const WriteModal = ({
     setValue,
     getValues,
     control,
+    reset,
     formState: { errors },
   } = useForm<WriteLetterReq>({
     defaultValues: {
@@ -68,7 +69,26 @@ const WriteModal = ({
       onObjectKeyChange: (value) => setValue("objectKeys", value),
     });
 
+  // 모달이 열릴 때마다 폼 초기화
+  useEffect(() => {
+    if (isOpen) {
+      reset({
+        capsuleId: capsuleData.result.id.toString(),
+        content: "",
+        from: "",
+        objectKeys: "",
+      });
+      if (uploadedImageUrl) {
+        removeImage();
+      }
+    }
+  }, [isOpen]);
+
   const onSubmit = (data: WriteLetterReq) => {
+    if (!data.content?.trim()) {
+      alert("편지 내용을 입력해주세요.");
+      return;
+    }
     setIsConfirmOpen(true);
   };
 

--- a/app/(sub)/capsule-detail/_components/write-modal/index.tsx
+++ b/app/(sub)/capsule-detail/_components/write-modal/index.tsx
@@ -38,7 +38,6 @@ const WriteModal = ({
   const [isConfirmOpen, setIsConfirmOpen] = useState(false);
 
   const {
-    register,
     handleSubmit,
     setValue,
     getValues,
@@ -89,6 +88,13 @@ const WriteModal = ({
       alert("편지 내용을 입력해주세요.");
       return;
     }
+    
+    // 이미지 업로드 중이면 제출 불가
+    if (isUploading) {
+      alert("이미지 업로드 중입니다. 잠시만 기다려주세요.");
+      return;
+    }
+    
     setIsConfirmOpen(true);
   };
 
@@ -126,8 +132,12 @@ const WriteModal = ({
           >
             닫기
           </button>
-          <button type="submit" className={styles.title} disabled={isPending}>
-            {isPending ? "제출 중..." : "편지담기"}
+          <button 
+            type="submit" 
+            className={styles.title} 
+            disabled={isPending || isUploading}
+          >
+            {isPending ? "제출 중..." : isUploading ? "업로드 중..." : "편지담기"}
           </button>
         </div>
 
@@ -237,7 +247,10 @@ const WriteModal = ({
           openDate={formatOpenDateString(capsuleData.result.openAt)}
           isOpen={isConfirmOpen}
           close={() => setIsConfirmOpen(false)}
-          onConfirm={() => handleConfirm(getValues())}
+          onConfirm={() => {
+            const currentData = getValues();
+            handleConfirm(currentData);
+          }}
         />
       )}
     </Modal>

--- a/app/(sub)/capsule-detail/_components/write-modal/write-modal.css.ts
+++ b/app/(sub)/capsule-detail/_components/write-modal/write-modal.css.ts
@@ -11,6 +11,7 @@ export const container = style({
   ...screen.md({
     width: "60rem",
   }),
+  position: "relative",
 });
 
 export const sprinkleWrapper = style({
@@ -168,15 +169,11 @@ export const textareaContainer = style({
   display: "flex",
   alignItems: "center",
   justifyContent: "center",
-
   width: "100%",
   margin: "0 auto",
 });
 
 export const imageAddButton = style({
-  position: "absolute",
-  bottom: "1.4rem",
-  left: "0.8rem",
   display: "flex",
   alignItems: "center",
   gap: "0.8rem",
@@ -205,7 +202,7 @@ export const plusIconWrapper = style({
   padding: "0.7rem",
 });
 
-export const textarea = style({
+export const textareaDiv = style({
   background: themeVars.color.gradient.darkgray_bg_horizontal,
   border: "none",
   borderRadius: "12px",
@@ -214,9 +211,17 @@ export const textarea = style({
   width: "100%",
   height: "100%",
   resize: "none",
+  boxSizing: "border-box",
+  overflow: "scroll",
   "::placeholder": {
     color: themeVars.color.white[30],
   },
+});
+export const textarea = style({
+  color: themeVars.color.white[85],
+  width: "100%",
+  resize: "none",
+  height: "27rem",
 });
 
 export const imagePreviewContainer = style({
@@ -250,4 +255,13 @@ export const errorMessage = style({
   color: themeVars.color.white[100],
   fontWeight: "400",
   zIndex: 1,
+});
+
+export const imageAddButtonContainer = style({
+  display: "flex",
+  flexDirection: "column",
+  alignItems: "center",
+  position: "absolute",
+  bottom: "1.4rem",
+  left: "0.8rem",
 });

--- a/app/(sub)/capsule-detail/_components/write-modal/write-modal.css.ts
+++ b/app/(sub)/capsule-detail/_components/write-modal/write-modal.css.ts
@@ -150,6 +150,7 @@ export const senderInput = style({
   background: themeVars.color.white[7],
   borderRadius: "12px",
   padding: "1.2rem 2.0rem",
+  width: "100%",
   color: themeVars.color.white[85],
   "::placeholder": {
     color: themeVars.color.white[30],
@@ -203,6 +204,7 @@ export const plusIconWrapper = style({
 });
 
 export const textareaDiv = style({
+  position: "relative",
   background: themeVars.color.gradient.darkgray_bg_horizontal,
   border: "none",
   borderRadius: "12px",
@@ -264,4 +266,28 @@ export const imageAddButtonContainer = style({
   position: "absolute",
   bottom: "1.4rem",
   left: "0.8rem",
+});
+
+export const charCount = style({
+  position: "absolute",
+  right: "1.5rem",
+  bottom: "1.5rem",
+  ...themeVars.text.F15,
+  color: themeVars.color.white[30],
+  pointerEvents: "none",
+});
+
+export const senderInputContainer = style({
+  position: "relative",
+  width: "100%",
+});
+
+export const senderCharCount = style({
+  position: "absolute",
+  right: "1.5rem",
+  top: "50%",
+  transform: "translateY(-50%)",
+  ...themeVars.text.F15,
+  color: themeVars.color.white[30],
+  pointerEvents: "none",
 });

--- a/app/(sub)/capsule-detail/_components/write-modal/write-modal.css.ts
+++ b/app/(sub)/capsule-detail/_components/write-modal/write-modal.css.ts
@@ -7,15 +7,9 @@ export const container = style({
   background: themeVars.color.black["90_bg"],
   paddingLeft: "3.2rem",
   paddingRight: "3.2rem",
-  width: "100vw",
-  height: "100vh",
-
   borderRadius: 0,
-
   ...screen.md({
     width: "60rem",
-    maxWidth: "100vw",
-    height: "100vh",
   }),
 });
 

--- a/app/(sub)/create-capsule/page.tsx
+++ b/app/(sub)/create-capsule/page.tsx
@@ -8,13 +8,13 @@ import type { CreateCapsuleReq } from "@/shared/types/api/capsule";
 import NavbarDetail from "@/shared/ui/navbar/navbar-detail";
 import PopupCancelCreation from "@/shared/ui/popup/popup-cancel-creation";
 import { createISOString, getDate } from "@/shared/utils/date";
-import { overlay } from "overlay-kit";
 import { FormProvider, type SubmitHandler, useForm } from "react-hook-form";
 import CompleteStep from "./_components/steps/complete-step";
 import DateStep from "./_components/steps/date-step";
 import IntroStep from "./_components/steps/intro-step";
 import PrivateStep from "./_components/steps/privacy-step";
 import * as styles from "./page.css";
+import { useOverlay } from "@/shared/hooks/use-overlay";
 
 type CreateCapsuleForm = {
   title: string;
@@ -33,6 +33,7 @@ interface CapsuleInfo {
 const CreateCapsule = () => {
   const { Funnel, Step, setStep, step } = useFunnel();
   const [capsuleInfo, setCapsuleInfo] = useState<CapsuleInfo | null>(null);
+  const { open } = useOverlay();
 
   const { mutate: createCapsuleMutate, isPending } = useCreateCapsule();
 
@@ -87,7 +88,7 @@ const CreateCapsule = () => {
             <button
               className={styles.closeButton}
               onClick={() =>
-                overlay.open(({ isOpen, close }) => (
+                open(({ isOpen, close }) => (
                   <PopupCancelCreation isOpen={isOpen} close={close} />
                 ))
               }

--- a/shared/hooks/use-overlay.ts
+++ b/shared/hooks/use-overlay.ts
@@ -1,0 +1,46 @@
+import { useCallback, useEffect, useState } from "react";
+import { overlay } from "overlay-kit";
+import type { OverlayAsyncControllerComponent } from "overlay-kit";
+
+const randomId = () => `overlay-${Math.random().toString(36).slice(2, 11)}`;
+
+export const useOverlay = () => {
+  const [defaultOverlayId] = useState<string>(randomId());
+  const [overlayId, setOverlayId] = useState<string>(defaultOverlayId);
+
+  const open = useCallback(
+    (
+      controller: Parameters<typeof overlay.open>[0],
+      options?: Parameters<typeof overlay.open>[1]
+    ) => {
+      const id = options?.overlayId ? options.overlayId : defaultOverlayId;
+      setOverlayId(id);
+      return overlay.open(controller, { ...options, overlayId: id });
+    },
+    [defaultOverlayId]
+  );
+
+  const close = useCallback(() => overlay.close(overlayId), [overlayId]);
+  const unmount = useCallback(() => overlay.unmount(overlayId), [overlayId]);
+
+  const openAsync = useCallback(
+    <T>(
+      controller: OverlayAsyncControllerComponent<T>,
+      options?: { overlayId?: string | undefined } | undefined
+    ): Promise<T> => {
+      const id = options?.overlayId ? options.overlayId : defaultOverlayId;
+      setOverlayId(id);
+      return overlay.openAsync<T>(controller, { ...options, overlayId: id });
+    },
+    [defaultOverlayId]
+  );
+
+  // 컴포넌트가 언마운트될 때 자동으로 오버레이도 언마운트
+  useEffect(() => {
+    return () => {
+      unmount();
+    };
+  }, [unmount]);
+
+  return { open, close, unmount, openAsync };
+};

--- a/shared/utils/oauth.ts
+++ b/shared/utils/oauth.ts
@@ -28,4 +28,19 @@ export const oauthUtils = {
   hasNextUrl: (): boolean => {
     return sessionStorage.getItem(OAUTH_NEXT_KEY) !== null;
   },
+
+  /**
+   * 현재 경로와 쿼리 파라미터를 조합하여 완전한 URL을 생성합니다.
+   * @param pathname - 현재 경로
+   * @param searchParams - 쿼리 파라미터
+   * @returns 완전한 URL 문자열
+   */
+  buildCurrentUrl: (
+    pathname: string,
+    searchParams?: URLSearchParams | null
+  ): string => {
+    return `${pathname}${
+      searchParams?.toString() ? `?${searchParams.toString()}` : ""
+    }`;
+  },
 };


### PR DESCRIPTION
## 📌 Summary

> - #183 

## 📚 Tasks
- 텍스트 Input이 이미지 추가 버튼 영역을 가리지 않도록 수정
- use-overlay훅 추가 후 적용 (컴포넌트 언마운트 시 오버레이 자동 정리되도록, 브라우저 뒤로가기 대응)
- 글자수에 따른 유효성 검증 추가 및 아무런 입력이 없을 때의 검증도 추가
- 모달 닫혔다가 열리면 폼 초기화되도록 수정

## 👀 To Reviewer
overlay-kit에서 컴포넌트 언마운트 시 오버레이를 자동 정리하는 기능을 제공하지 않고 있어요. 레포에서 이슈를 좀 뒤져보니, 라이브러리 딴에서는 의도적으로 그렇게 했더라고용 그래서use-overlay라는 헬퍼 훅을 만들어서 자동 정리되는 기능을 추가했어요. 

```typeScript
// 기존 방식 (여전히 사용 가능)
overlay.open(({ isOpen, close }) => (
  <Modal isOpen={isOpen} onClose={close} />
));

// 새로운 방식 (자동 정리 기능 추가)
const { open } = useOverlay();
open(({ isOpen, close }) => (
  <Modal isOpen={isOpen} onClose={close} />
));

```
-> 새로운 방식으로 모두 수정해놨습니다.

지금 모든 유효성 검증을 alert로 하고 있는데, 디자인측에 알리고 인지하고있도록 해야할거같아용
그리고 서버측 말론 object key가 안넘어온다그랬는데, 이미지 업로드 되기 전에 폼이 제출돼서그런거라고 추측해서, isUploading이면 제출할 수 없게 alert 띄우도록 했어요, 근데 제 로컬환경에서 이미지 버튼이 죽어도 안눌려서 확인을 못하네요 ㅎㅎ; 이거 제대로 넘어오는지 마저 확인해주실수 있나여 @seung365 

<!--
## 📸 Screenshot

(기재 내용 없을 경우 섹션 삭제) 작업한 내용에 대한 스크린샷을 첨부해주세요. 필요시 .gif 형식으로 첨부해주세요.
-->
