### PR TITLE
Fix: 사용자와 상호작용할 때만 user 쿼리 실행하도록 수정

### DIFF
--- a/app/(sub)/capsule-detail/[invite-code]/[id]/page.tsx
+++ b/app/(sub)/capsule-detail/[invite-code]/[id]/page.tsx
@@ -29,6 +29,7 @@ import { useLeaveCapsule } from "@/shared/api/mutations/capsule";
 import * as styles from "./page.css";
 import { oauthUtils } from "@/shared/utils/oauth";
 import { useOverlay } from "@/shared/hooks/use-overlay";
+import { useState} from "react";
 
 const CapsuleDetailPage = () => {
   const params = useParams();
@@ -37,7 +38,13 @@ const CapsuleDetailPage = () => {
   const { data, isLoading, isError } = useQuery(
     capsuleQueryOptions.capsuleDetail(id),
   );
-  const { data: user } = useQuery(userQueryOptions.userInfo());
+  const [shouldCheckUser, setShouldCheckUser] = useState(false);
+
+  const { data: user } = useQuery(
+    userQueryOptions.userInfo({ 
+      enabled: shouldCheckUser
+    })
+  );
   const { mutate: leaveCapsule } = useLeaveCapsule();
   const router = useRouter();
   const pathname = usePathname();
@@ -45,7 +52,6 @@ const CapsuleDetailPage = () => {
   const { open } = useOverlay();
 
   const isLoggedIn = !!user?.result;
-
   if (isLoading) {
     return <LoadingSpinner loading={true} size={20} />;
   }
@@ -57,6 +63,11 @@ const CapsuleDetailPage = () => {
   const { result } = data;
 
   const handleLikeToggle = (nextLiked: boolean) => {
+    if (!shouldCheckUser) {
+      setShouldCheckUser(true);
+      return;
+    }
+    
     if (!isLoggedIn) {
       const current = oauthUtils.buildCurrentUrl(pathname, searchParams);
       oauthUtils.saveNextUrl(current);


### PR DESCRIPTION
## 📌 Summary

_해당 PR에 대한 작업 내용을 요약하여 작성해주세요._

## 📚 Tasks

- 사용자와 상호작용할 때만 user 쿼리 실행하도록 수정


## 👀 To Reviewer
401에러 전역처리하니까 캡슐 상세에서 user쿼리 호출해서 로그인 여부 판별하고있었어서,, 캡슐 상세에서 바로 로그인페이지로 가버리더라구요ㅜ
사용자와 상호작용할 때만 user쿼리 실행되도록, 상태하나 추가해서 enabled 조건으로 추가했습니다!(더좋은방법 없을까여,,)

<!--
## 📸 Screenshot

(기재 내용 없을 경우 섹션 삭제) 작업한 내용에 대한 스크린샷을 첨부해주세요. 필요시 .gif 형식으로 첨부해주세요.
-->
