### PR TITLE
QA: 수정된 레이아웃 반영

### DIFF
--- a/app/(main)/layout.tsx
+++ b/app/(main)/layout.tsx
@@ -1,10 +1,10 @@
-import { mainLayout } from "@/shared/styles/base/global.css";
+import { maxWidth } from "@/shared/styles/base/global.css";
 import NavbarMain from "@/shared/ui/navbar/navbar-main";
 import type { ReactNode } from "react";
 
 const MainLayout = ({ children }: { children: ReactNode }) => {
   return (
-    <div className={mainLayout}>
+    <div className={maxWidth}>
       <NavbarMain />
       {children}
     </div>

--- a/app/(sub)/capsule-detail/[invite-code]/[id]/page.css.ts
+++ b/app/(sub)/capsule-detail/[invite-code]/[id]/page.css.ts
@@ -5,7 +5,9 @@ export const container = style({
   display: "flex",
   flexDirection: "column",
   gap: "1.6rem",
-  margin: "0 1.6rem",
+  margin: "0 auto",
+  maxWidth: "90rem",
+  padding: "0 1.6rem",
 });
 
 export const textHighlight = style({

--- a/app/(sub)/capsule-detail/[invite-code]/[id]/page.tsx
+++ b/app/(sub)/capsule-detail/[invite-code]/[id]/page.tsx
@@ -121,24 +121,25 @@ const CapsuleDetailPage = () => {
           );
         }}
       />
-      <RevealMotion>
-        <InfoTitle
-          title={result.title}
-          participantCount={result.participantCount}
-          joinLettersCount={result.letterCount}
-        />
-      </RevealMotion>
-      <CapsuleImage imageUrl={result.beadVideoUrl} />
-      <div className={styles.container}>
-        <RevealMotion delay={0.8}>
-          {result.subtitle && <CaptionSection description={result.subtitle} />}
+      
+        <RevealMotion>
+          <InfoTitle
+            title={result.title}
+            participantCount={result.participantCount}
+            joinLettersCount={result.letterCount}
+          />
         </RevealMotion>
-        <RevealMotion delay={1.2}>
-          <OpenInfoSection openAt={formatDateTime(result.openAt)} />
-        </RevealMotion>
-      </div>
-      <ResponsiveFooter capsuleData={data} isLoggedIn={isLoggedIn} />
-      {result.status !== "WRITABLE" && <InfoToast status={result.status} />}
+        <CapsuleImage imageUrl={result.beadVideoUrl} />
+        <div className={styles.container}>
+          <RevealMotion delay={0.8}>
+            {result.subtitle && <CaptionSection description={result.subtitle} />}
+          </RevealMotion>
+          <RevealMotion delay={1.2}>
+            <OpenInfoSection openAt={formatDateTime(result.openAt)} />
+          </RevealMotion>
+        </div>
+        <ResponsiveFooter capsuleData={data} isLoggedIn={isLoggedIn} />
+        {result.status !== "WRITABLE" && <InfoToast status={result.status} />}
     </>
   );
 };

--- a/app/(sub)/capsule-detail/_components/responsive-footer/responsive-footer.css.ts
+++ b/app/(sub)/capsule-detail/_components/responsive-footer/responsive-footer.css.ts
@@ -11,9 +11,10 @@ export const container = style({
   ...screen.md({
     position: "fixed",
     bottom: "7rem",
-    width: "calc(80rem - 3.4rem)",
+    left: "50%",
+    transform: "translateX(-50%)",
+    width: "calc(90rem - 3.4rem)",
     flexDirection: "row",
-    margin: "0 1.7rem",
     padding: "1.2rem 1.2rem 1.2rem 2.4rem",
     background: themeVars.color.gradient.darkgray_op,
   }),

--- a/shared/styles/base/global.css.ts
+++ b/shared/styles/base/global.css.ts
@@ -48,7 +48,7 @@ export const globalLayout = style({
 });
 
 export const maxWidth = style({
-  maxWidth: "800px",
+  maxWidth: "1200px",
   width: "100%",
 });
 

--- a/shared/styles/base/global.css.ts
+++ b/shared/styles/base/global.css.ts
@@ -51,8 +51,3 @@ export const maxWidth = style({
   maxWidth: "1200px",
   width: "100%",
 });
-
-export const mainLayout = style({
-  maxWidth: "1200px",
-  width: "100%",
-});

--- a/shared/ui/navbar/navbar-detail/navbar-detail.css.ts
+++ b/shared/ui/navbar/navbar-detail/navbar-detail.css.ts
@@ -12,7 +12,7 @@ export const container = style({
   left: "50%",
   transform: "translateX(-50%)",
   width: "100%",
-  maxWidth: "80rem",
+  maxWidth: "120rem",
 });
 
 export const iconButton = style({


### PR DESCRIPTION
## 📌 Summary

> - #189 

## 📚 Tasks

- 전체 최대넓이 1200px 고정

## 👀 To Reviewer
main, sub는 상단 헤더 기준으로 나눠놓은거라 그대로 유지해야될 것 같습니다~!

<!--
## 📸 Screenshot

(기재 내용 없을 경우 섹션 삭제) 작업한 내용에 대한 스크린샷을 첨부해주세요. 필요시 .gif 형식으로 첨부해주세요.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 스타일
  - 메인 및 상세 레이아웃의 최대 너비를 확대(약 1200px)하고 중앙 정렬로 가독성 개선
  - 캡슐 상세 페이지 컨테이너 중앙 배치 및 좌우 패딩 추가로 여백 일관성 향상
  - 반응형 푸터: 중간 화면 이상에서 가로 중앙 정렬 및 가용 너비 확장으로 안정적 배치
  - 상세 네비게이션 바 최대 너비 확대로 넓은 화면 활용성 개선
- 기타
  - 일부 파일 포맷 정리(동작 변화 없음)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->