### PR TITLE
Fix: 모달 닫힘 경고 팝업 뜨도록 수정 및 esc props 전달

### DIFF
--- a/app/(sub)/capsule-detail/[invite-code]/[id]/letters/_components/letter-detail-modal/index.tsx
+++ b/app/(sub)/capsule-detail/[invite-code]/[id]/letters/_components/letter-detail-modal/index.tsx
@@ -23,7 +23,6 @@ const LetterDetailModal = ({
       overlayClassName={styles.modalOverlay}
       contentClassName={styles.modalContent}
       fullScreenOnMobile={false}
-      closeOnOverlayClick={true}
     >
       <section className={styles.container}>
         {imageUrl && (

--- a/app/(sub)/capsule-detail/_components/modal/index.tsx
+++ b/app/(sub)/capsule-detail/_components/modal/index.tsx
@@ -13,6 +13,7 @@ interface ModalProps {
   contentClassName?: string;
   fullScreenOnMobile?: boolean;
   closeOnOverlayClick?: boolean;
+  closeOnEsc?: boolean;
 }
 
 export default function Modal({
@@ -22,17 +23,20 @@ export default function Modal({
   overlayClassName,
   contentClassName,
   fullScreenOnMobile = true,
-  closeOnOverlayClick = false,
+  closeOnOverlayClick = true,
+  closeOnEsc = true,
 }: ModalProps) {
   useEffect(() => {
     const handleEscapeKey = (event: KeyboardEvent) => {
-      if (event.key === "Escape" && isOpen) {
+      if (event.key === "Escape" && isOpen && closeOnEsc) {
         onClose();
       }
     };
 
     if (isOpen) {
-      document.addEventListener("keydown", handleEscapeKey);
+      if (closeOnEsc) {
+        document.addEventListener("keydown", handleEscapeKey);
+      }
       document.body.style.overflow = "hidden";
     }
 
@@ -40,7 +44,7 @@ export default function Modal({
       document.removeEventListener("keydown", handleEscapeKey);
       document.body.style.overflow = "unset";
     };
-  }, [isOpen, onClose]);
+  }, [isOpen, onClose, closeOnEsc]);
 
   if (!isOpen) return null;
 

--- a/shared/ui/popup/popup-warning-letter/index.tsx
+++ b/shared/ui/popup/popup-warning-letter/index.tsx
@@ -6,12 +6,14 @@ interface PopupWarningLetterProps {
   isOpen: boolean;
   close: () => void;
   confirm: () => void;
+  onGoBack?: () => void;
 }
 
 const PopupWarningLetter = ({
   isOpen,
   close,
   confirm,
+  onGoBack,
 }: PopupWarningLetterProps) => {
   return (
     <Popup open={isOpen} close={close}>
@@ -25,8 +27,16 @@ const PopupWarningLetter = ({
         </div>
       </Popup.Title>
       <Popup.Actions>
-        <Popup.Button onClick={close} className={styles.content}>돌아가기</Popup.Button>
-        <Popup.Button className={styles.continueButton} onClick={confirm}>
+        <Popup.Button onClick={onGoBack || close} className={styles.content}>
+          돌아가기
+        </Popup.Button>
+        <Popup.Button
+          className={styles.continueButton}
+          onClick={(e) => {
+            e.stopPropagation();
+            confirm();
+          }}
+        >
           계속 쓰기
         </Popup.Button>
       </Popup.Actions>


### PR DESCRIPTION
## 📌 Summary

> - #196 

## 📚 Tasks

- 모달 닫힘 경고 팝업 뜨도록 수정 
- modal esc props 전달

## 👀 To Reviewer

아무 내용도 없을땐 popup이 뜨지 않고 바로 닫히도록 하였습니다. 또한 write-modal의 경우 esc로 닫히지 않게 했습니다.

## 📸 Screenshot


https://github.com/user-attachments/assets/b603ebde-4ab2-4c7b-a8a4-85d23fd7bc29



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 편지 작성 모달에 서버 제출 기능과 로딩 표시를 추가했습니다. 성공/실패 처리 및 제출 전 경고 흐름을 지원합니다.
  - 경고 팝업에 돌아가기 동작을 추가하여 폼 초기화 및 이미지 제거 후 닫을 수 있습니다.
  - 모달의 기본 동작을 개선해 오버레이 클릭으로 닫기가 기본 활성화되었습니다.

- Bug Fixes
  - 작성 모달에서 ESC/오버레이로의 오작동 닫힘을 방지했습니다(명시적 버튼/성공 시에만 닫힘).
  - 경고 팝업 버튼 클릭 시 이벤트 버블링으로 인한 의도치 않은 동작을 방지했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->